### PR TITLE
Thread module to be used for server connection handlers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod cli;
 pub mod error;
 pub mod helpers;
+pub mod net;
 pub mod report;
 pub mod threshold;
 pub mod user;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,0 +1,2 @@
+pub mod server;
+pub mod thread;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,2 +1,5 @@
-pub mod server;
-pub mod thread;
+pub use self::thread::Thread;
+pub use self::server::Server;
+
+mod server;
+mod thread;

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -6,6 +6,7 @@ pub struct Server {
 }
 
 impl Server {
+    #[must_use]
     pub fn new() -> Server {
         Server {
             connection_handler_thread: Thread::new(),
@@ -22,6 +23,12 @@ impl Server {
             // read
             // write
         });
+    }
+}
+
+impl Default for Server {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -1,0 +1,40 @@
+#[cfg(feature = "debug")]
+use crate::net::thread::Thread;
+
+pub struct Server {
+    connection_handler_thread: Thread,
+}
+
+impl Server {
+    pub fn new() -> Server {
+        Server {
+            connection_handler_thread: Thread::new(),
+        }
+    }
+
+    pub fn start(&self) {
+        self.start_connection_handler();
+    }
+
+    fn start_connection_handler(&self) {
+        self.connection_handler_thread.execute(|| {
+            // listen
+            // read
+            // write
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Server;
+    use std::thread;
+    use std::time;
+
+    #[test]
+    fn test_no_panic() {
+        let server = Server::new();
+        server.start();
+        thread::sleep(time::Duration::from_millis(500));
+    }
+}

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -1,5 +1,4 @@
-#[cfg(feature = "debug")]
-use crate::net::thread::Thread;
+use crate::net::Thread;
 
 pub struct Server {
     connection_handler_thread: Thread,

--- a/src/net/thread.rs
+++ b/src/net/thread.rs
@@ -20,6 +20,7 @@ pub enum Message {
 }
 
 impl Thread {
+    #[must_use]
     pub fn new() -> Thread {
         let (sender, receiver) = mpsc::channel();
         let receiver = Arc::new(Mutex::new(receiver));
@@ -30,6 +31,9 @@ impl Thread {
         }
     }
 
+    /// Sends a function to the running thread for it to be executed.
+    /// # Panics
+    /// If the thread has been terminated.
     pub fn execute<F>(&self, f: F)
     where
         F: FnOnce() + Send + 'static,
@@ -37,6 +41,12 @@ impl Thread {
         let job = Box::new(f);
 
         self.sender.send(Message::NewJob(job)).unwrap();
+    }
+}
+
+impl Default for Thread {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/net/thread.rs
+++ b/src/net/thread.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "debug")]
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 

--- a/src/net/thread.rs
+++ b/src/net/thread.rs
@@ -1,0 +1,76 @@
+#[cfg(feature = "debug")]
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+
+pub struct Thread {
+    worker: Worker,
+    sender: mpsc::Sender<Message>,
+}
+
+pub struct Worker {
+    id: usize,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+type Job = Box<dyn FnOnce() + Send + 'static>;
+
+pub enum Message {
+    NewJob(Job),
+    Terminate,
+}
+
+impl Thread {
+    pub fn new() -> Thread {
+        let (sender, receiver) = mpsc::channel();
+        let receiver = Arc::new(Mutex::new(receiver));
+
+        Thread {
+            worker: Worker::new(0, receiver),
+            sender,
+        }
+    }
+
+    pub fn execute<F>(&self, f: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let job = Box::new(f);
+
+        self.sender.send(Message::NewJob(job)).unwrap();
+    }
+}
+
+impl Drop for Thread {
+    fn drop(&mut self) {
+        println!("Terminating thread {}", self.worker.id);
+        self.sender.send(Message::Terminate).unwrap();
+
+        if let Some(thread) = self.worker.thread.take() {
+            thread.join().unwrap();
+        }
+    }
+}
+
+impl Worker {
+    fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Message>>>) -> Worker {
+        let thread = thread::spawn(move || loop {
+            let message = receiver.lock().unwrap().recv().unwrap();
+
+            match message {
+                Message::NewJob(job) => {
+                    println!("Worker {} received a job; executing.", id);
+                    job();
+                }
+                Message::Terminate => {
+                    println!("Worker {} is shutting down.", id);
+                    break;
+                }
+            }
+        });
+
+        Worker {
+            id,
+            thread: Some(thread),
+        }
+    }
+}


### PR DESCRIPTION
A simple thread module with mspc channel for sending jobs / terminating the thread. A thread will wait indefinitely for incoming messages from the caller (`Receiver`'s `recv()` is blocking). Message will either contain a function to be executed by the thread, or a message to let the thread to terminate itself gracefully.

I'll use this thread mod to create a server module in the next diff.

```
❯ cargo test --lib net -- --nocapture
   Compiling raw-ipa v0.1.0 (/Users/taiki/src/raw-ipa)
    Finished test [unoptimized + debuginfo] target(s) in 0.43s
     Running unittests (target/debug/deps/raw_ipa-6735d863a171d867)

running 1 test
Worker 0 received a job; executing.
Terminating thread 0
Worker 0 is shutting down.
test net::server::tests::test_no_panic ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.51s
```