### PR TITLE
Thread module to be used for server connection handler

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     NotEnoughHelpers,
     NotFound,
     TooManyHelpers,
+    DeadThread(std::sync::mpsc::SendError<crate::net::Message>),
 
     #[cfg(feature = "cli")]
     Hex(hex::FromHexError),
@@ -44,6 +45,8 @@ impl std::fmt::Display for Error {
 }
 
 forward_errors! {
+    std::sync::mpsc::SendError<crate::net::Message> => DeadThread,
+
     #[cfg(feature = "cli")]
     hex::FromHexError => Hex,
     std::io::Error => Io,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod cli;
 pub mod error;
 pub mod helpers;
+pub mod net;
 pub mod report;
 pub mod threshold;
 pub mod user;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,0 +1,5 @@
+pub use self::server::Server;
+pub use self::thread::Thread;
+
+mod server;
+mod thread;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,5 +1,5 @@
 pub use self::server::Server;
-pub use self::thread::Thread;
+pub use self::thread::{Message, Thread};
 
 mod server;
 mod thread;

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -1,0 +1,46 @@
+use crate::net::Thread;
+
+pub struct Server {
+    connection_handler_thread: Thread,
+}
+
+impl Server {
+    #[must_use]
+    pub fn new() -> Server {
+        Server {
+            connection_handler_thread: Thread::new(),
+        }
+    }
+
+    pub fn start(&self) {
+        self.start_connection_handler();
+    }
+
+    fn start_connection_handler(&self) {
+        self.connection_handler_thread.execute(|| {
+            // listen
+            // read
+            // write
+        });
+    }
+}
+
+impl Default for Server {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Server;
+    use std::thread;
+    use std::time;
+
+    #[test]
+    fn test_no_panic() {
+        let server = Server::new();
+        server.start();
+        thread::sleep(time::Duration::from_millis(500));
+    }
+}

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -16,12 +16,17 @@ impl Server {
         self.start_connection_handler();
     }
 
+    /// Spawns a new thread to handle incoming connections.
+    /// # Panics
+    /// If the thread could not be spawned.
     fn start_connection_handler(&self) {
-        self.connection_handler_thread.execute(|| {
+        if let Err(e) = self.connection_handler_thread.execute(|| {
             // listen
             // read
             // write
-        });
+        }) {
+            panic!("Could not start the connection handler: {}", e);
+        }
     }
 }
 
@@ -34,13 +39,10 @@ impl Default for Server {
 #[cfg(test)]
 mod tests {
     use super::Server;
-    use std::thread;
-    use std::time;
 
     #[test]
-    fn test_no_panic() {
+    fn no_panic() {
         let server = Server::new();
         server.start();
-        thread::sleep(time::Duration::from_millis(500));
     }
 }

--- a/src/net/thread.rs
+++ b/src/net/thread.rs
@@ -1,12 +1,15 @@
+use log::{error, info};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
+
+use crate::error::Res;
 
 pub struct Thread {
     worker: Worker,
     sender: mpsc::Sender<Message>,
 }
 
-pub struct Worker {
+struct Worker {
     id: usize,
     thread: Option<thread::JoinHandle<()>>,
 }
@@ -25,21 +28,23 @@ impl Thread {
         let receiver = Arc::new(Mutex::new(receiver));
 
         Thread {
-            worker: Worker::new(0, receiver),
+            worker: Worker::spawn(0, receiver),
             sender,
         }
     }
 
     /// Sends a function to the running thread for it to be executed.
-    /// # Panics
-    /// If the thread has been terminated.
-    pub fn execute<F>(&self, f: F)
+    /// # Errors
+    ///  If the thread has been terminated.
+    pub fn execute<F>(&self, f: F) -> Res<()>
     where
         F: FnOnce() + Send + 'static,
     {
         let job = Box::new(f);
 
-        self.sender.send(Message::NewJob(job)).unwrap();
+        self.sender.send(Message::NewJob(job))?;
+
+        Ok(())
     }
 }
 
@@ -51,27 +56,40 @@ impl Default for Thread {
 
 impl Drop for Thread {
     fn drop(&mut self) {
-        println!("Terminating thread {}", self.worker.id);
-        self.sender.send(Message::Terminate).unwrap();
-
-        if let Some(thread) = self.worker.thread.take() {
-            thread.join().unwrap();
+        info!("Terminating thread {}", self.worker.id);
+        if let Ok(()) = self.sender.send(Message::Terminate) {
+            if let Some(thread) = self.worker.thread.take() {
+                thread.join().unwrap();
+            }
         }
     }
 }
 
 impl Worker {
-    fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Message>>>) -> Worker {
+    fn spawn(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Message>>>) -> Worker {
         let thread = thread::spawn(move || loop {
-            let message = receiver.lock().unwrap().recv().unwrap();
+            let message: Message;
+
+            // Receive a message and release the lock before executing anything else.
+            if let Ok(receiver) = receiver.lock() {
+                if let Ok(msg) = receiver.recv() {
+                    message = msg;
+                } else {
+                    error!("Sender channel is closed.");
+                    break;
+                }
+            } else {
+                error!("Failed to lock the mutex.");
+                break;
+            }
 
             match message {
                 Message::NewJob(job) => {
-                    println!("Worker {} received a job; executing.", id);
+                    info!("Worker {} received a job; executing.", id);
                     job();
                 }
                 Message::Terminate => {
-                    println!("Worker {} is shutting down.", id);
+                    info!("Worker {} is shutting down.", id);
                     break;
                 }
             }

--- a/src/net/thread.rs
+++ b/src/net/thread.rs
@@ -1,0 +1,85 @@
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+
+pub struct Thread {
+    worker: Worker,
+    sender: mpsc::Sender<Message>,
+}
+
+pub struct Worker {
+    id: usize,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+type Job = Box<dyn FnOnce() + Send + 'static>;
+
+pub enum Message {
+    NewJob(Job),
+    Terminate,
+}
+
+impl Thread {
+    #[must_use]
+    pub fn new() -> Thread {
+        let (sender, receiver) = mpsc::channel();
+        let receiver = Arc::new(Mutex::new(receiver));
+
+        Thread {
+            worker: Worker::new(0, receiver),
+            sender,
+        }
+    }
+
+    /// Sends a function to the running thread for it to be executed.
+    /// # Panics
+    /// If the thread has been terminated.
+    pub fn execute<F>(&self, f: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let job = Box::new(f);
+
+        self.sender.send(Message::NewJob(job)).unwrap();
+    }
+}
+
+impl Default for Thread {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for Thread {
+    fn drop(&mut self) {
+        println!("Terminating thread {}", self.worker.id);
+        self.sender.send(Message::Terminate).unwrap();
+
+        if let Some(thread) = self.worker.thread.take() {
+            thread.join().unwrap();
+        }
+    }
+}
+
+impl Worker {
+    fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Message>>>) -> Worker {
+        let thread = thread::spawn(move || loop {
+            let message = receiver.lock().unwrap().recv().unwrap();
+
+            match message {
+                Message::NewJob(job) => {
+                    println!("Worker {} received a job; executing.", id);
+                    job();
+                }
+                Message::Terminate => {
+                    println!("Worker {} is shutting down.", id);
+                    break;
+                }
+            }
+        });
+
+        Worker {
+            id,
+            thread: Some(thread),
+        }
+    }
+}


### PR DESCRIPTION
A simple thread module with mspc channel for sending jobs / terminating the thread. A thread will wait indefinitely for incoming messages from the caller (`Receiver`'s `recv()` is blocking). Message will either contain a function to be executed by the thread, or a message to let the thread to terminate itself gracefully.

I'll use this thread mod to create a server module in the next diff.

```
❯ cargo test --lib net -- --nocapture
   Compiling raw-ipa v0.1.0 (/Users/taiki/src/raw-ipa)
    Finished test [unoptimized + debuginfo] target(s) in 0.43s
     Running unittests (target/debug/deps/raw_ipa-6735d863a171d867)

running 1 test
Worker 0 received a job; executing.
Terminating thread 0
Worker 0 is shutting down.
test net::server::tests::test_no_panic ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.51s
```