### PR TITLE
[Stacked Diff] Thread pool object for concurrent connections handling

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,5 +1,5 @@
 pub use self::server::Server;
-pub use self::thread::{Message, Thread};
+pub use self::thread::{Message, Pool};
 
 mod server;
 mod thread;

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -1,19 +1,26 @@
-use crate::net::Thread;
+use crate::net::Pool;
+use log::warn;
 
 pub struct Server {
-    connection_handler_thread: Thread,
+    connection_handler_thread: Pool,
 }
 
 impl Server {
     #[must_use]
     pub fn new() -> Server {
         Server {
-            connection_handler_thread: Thread::new(),
+            connection_handler_thread: Pool::new(1),
         }
     }
 
     pub fn start(&self) {
         self.start_connection_handler();
+    }
+
+    pub fn stop(&mut self) {
+        if let Err(e) = self.connection_handler_thread.shutdown() {
+            warn!("Graceful shutdown failed: {}", e);
+        }
     }
 
     /// Spawns a new thread to handle incoming connections.
@@ -42,7 +49,10 @@ mod tests {
 
     #[test]
     fn no_panic() {
-        let server = Server::new();
+        let mut server = Server::new();
+
         server.start();
+
+        server.stop();
     }
 }


### PR DESCRIPTION
This is a stacked branch of my previous PR: [Thread module to be used for server connection handler #18](https://github.com/martinthomson/raw-ipa/pull/18)
New commits for this pull request begin at [886ac46](https://github.com/martinthomson/raw-ipa/commit/886ac46cd482407befd3e7e78a7e5162997b6cf6)

This diff implements `Pool` which consists of a vector of `Thread`s. Now, a single thread object is a size(1) `Pool`.