### PR TITLE
[Stacked Diff] Implement basic networking for stream IO over TCP

### DIFF
--- a/src/net/handler.rs
+++ b/src/net/handler.rs
@@ -1,0 +1,138 @@
+use crate::net::Pool;
+use log::{error, info, trace};
+use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Formatter};
+#[cfg(feature = "enable-serde")]
+use std::io::prelude::*;
+use std::net::{SocketAddr, TcpListener, TcpStream};
+
+/// List of commands which can be handled by structs that implement ``CommandHandler`` trait.
+/// We'll probably need to create separate sets of commands for different protocols (server roles)
+/// such as MPC operations, health check, internal IPC, etc. For now, just name this enum "Command".
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub(crate) enum Command {
+    Echo(String),
+}
+
+#[cfg(feature = "debug")]
+impl Debug for Command {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        f.write_str("Command::")?;
+        match self {
+            Self::Echo(_) => f.write_str("Echo"),
+        }
+    }
+}
+
+trait CommandHandler {
+    fn handle_command(command: Command, buf: &mut [u8]);
+}
+
+/// A TCP connection handler.
+///
+/// Waits for incoming connections on a given internet address. Once a connection is accepted, its
+/// stream will be sent to one of child threads, and immediately starts listening for new connections.
+pub(crate) struct TcpConnection {
+    addr: SocketAddr,
+    pool_size: usize,
+}
+
+impl TcpConnection {
+    pub fn new(addr: SocketAddr, connection_count: usize) -> Self {
+        Self {
+            addr,
+            pool_size: connection_count,
+        }
+    }
+
+    /// Waits and handles incoming connections concurrently using a thread pool.
+    pub fn handle(&self) -> impl FnOnce() {
+        let addr = self.addr;
+        let pool_size = self.pool_size;
+
+        // TODO: This function returns a closure to be passed to ``Pool::execute`` rather than called from a closure.
+        // This is because this function owns a ``Pool`` which doesn't implement ``Send`` trait, thus not thread safe
+        // from rust compiler's POV. This needs to be rewritten but I'll leave it for now.
+        move || {
+            let listener = TcpListener::bind(addr).expect("Could not bind to the given address.");
+            let pool = Pool::new(pool_size);
+
+            info!("Listening for incoming connections...");
+
+            // TODO: Since incoming() is blocking, this thread will keep running unless a caller is dropped.
+            // We can implement a platform-specific signal to shutdown reads on the socket which will cause the
+            // incoming() iterator to return an error.
+            for stream in listener.incoming() {
+                match stream {
+                    Ok(stream) => {
+                        info!("Accepted a new connection.");
+
+                        if pool.execute(|| Self::handle_connection(stream)).is_err() {
+                            error!("Failed to create a worker thread to handle the connection.");
+                            // Continue processing incoming connections with other workers.
+                        }
+                    }
+                    Err(e) => {
+                        error!("Failed to accept: {}", e);
+                        // The error could be recoverable, but we'll just shutdown the connection handler for now.
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handles stream IO on an accepted connection. Data being sent are serialized ``Command`` enum.
+    fn handle_connection(mut stream: TcpStream) {
+        let mut buffer = [0; 1024];
+        let mut read_bytes = 0;
+
+        // TODO: Accept >1024 bytes
+        match stream.read(&mut buffer) {
+            Ok(0) => return,
+            Ok(n) => {
+                read_bytes = n;
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => {
+                error!("Stream read failed: {}", e);
+                return;
+            }
+        }
+
+        let serialized = String::from_utf8_lossy(&buffer[..read_bytes]);
+
+        trace!("Request: {:?}", serialized);
+
+        let deserialized: Result<Command, _> = serde_json::from_str(&serialized);
+        let mut buffer = [0; 1024];
+
+        match deserialized {
+            Ok(command) => {
+                Self::handle_command(command, &mut buffer);
+            }
+            Err(_) => {
+                error!("Invalid command received: {}", serialized);
+            }
+        }
+
+        match stream.write_all(&buffer) {
+            Ok(_) => {}
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => {
+                error!("Stream write failed: {}", e);
+            }
+        }
+    }
+}
+
+impl CommandHandler for TcpConnection {
+    fn handle_command(command: Command, buf: &mut [u8]) {
+        match command {
+            Command::Echo(s) => {
+                let bytes = s.as_bytes();
+                buf[..bytes.len()].copy_from_slice(bytes);
+            }
+        }
+    }
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,5 +1,5 @@
 pub use self::server::Server;
-pub use self::thread::{Message, Thread};
+pub use self::thread::{Message, Pool};
 
 mod server;
 mod thread;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,5 +1,5 @@
 pub use self::server::Server;
-pub use self::thread::{Message, Pool};
+pub use self::thread::{Job, Message, Pool};
 
 mod server;
 mod thread;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,5 +1,6 @@
-pub use self::server::Server;
-pub use self::thread::{Job, Message, Pool};
+pub use self::server::IPAService;
+pub use self::thread::{Message, Pool};
 
+mod handler;
 mod server;
 mod thread;

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -1,43 +1,26 @@
-use crate::net::{Job, Pool};
-use log::{error, info, trace, warn};
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
-use std::fmt::{Debug, Formatter};
-use std::io::prelude::*;
-use std::net::{SocketAddr, TcpListener, TcpStream};
+use super::handler::TcpConnection;
+use crate::net::Pool;
+use log::warn;
 
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-enum Command {
-    Echo(String),
+/// IPA Server prototype.
+/// Currently, we have one connection handler defined here which mocks RC communication.
+/// We can add more connection handlers
+pub struct IPAService {
+    rc_connection_handler_thread: Pool,
+    rc_connection_handler: TcpConnection,
 }
 
-#[cfg(feature = "debug")]
-impl Debug for Command {
-    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-        f.write_str("Command::")?;
-        match self {
-            Self::Echo(_) => f.write_str("Echo"),
-        }
-    }
-}
-
-pub struct Server {
-    connection_handler_thread: Pool,
-    connection_handler_addr: SocketAddr,
-    max_connection_count: usize,
-}
-
-impl Server {
+impl IPAService {
     #[must_use]
-    pub fn new(host: &str, port: u16, max_connection_count: usize) -> Server {
+    pub fn new(host: &str, port: u16, max_connection_count: usize) -> Self {
         let addr = format!("{}:{}", host, port)
             .parse()
             .expect("Invalid socket address.");
 
-        Server {
-            connection_handler_thread: Pool::new(1),
-            connection_handler_addr: addr,
-            max_connection_count,
+        Self {
+            rc_connection_handler_thread: Pool::new(1),
+            rc_connection_handler: TcpConnection::new(addr, max_connection_count),
         }
     }
 
@@ -46,7 +29,7 @@ impl Server {
     }
 
     pub fn stop(&mut self) {
-        if let Err(e) = self.connection_handler_thread.shutdown() {
+        if let Err(e) = self.rc_connection_handler_thread.shutdown() {
             warn!("Graceful shutdown failed: {}", e);
         }
     }
@@ -55,12 +38,9 @@ impl Server {
     /// # Panics
     /// If the thread could not be spawned.
     fn start_connection_handler(&self) {
-        let handler =
-            ConnectionHandler::new(self.connection_handler_addr, self.max_connection_count);
-
         if self
-            .connection_handler_thread
-            .execute(handler.start())
+            .rc_connection_handler_thread
+            .execute(self.rc_connection_handler.handle())
             .is_err()
         {
             panic!("Could not start the connection handler thread.");
@@ -68,110 +48,10 @@ impl Server {
     }
 }
 
-struct ConnectionHandler {
-    addr: SocketAddr,
-    pool_size: usize,
-}
-
-impl ConnectionHandler {
-    pub fn new(addr: SocketAddr, pool_size: usize) -> ConnectionHandler {
-        ConnectionHandler { addr, pool_size }
-    }
-
-    fn start(&self) -> Job {
-        let addr = self.addr;
-        let pool_size = self.pool_size;
-
-        Box::new(move || {
-            let listener = TcpListener::bind(addr).expect("Could not bind to the given address.");
-            let pool = Pool::new(pool_size);
-
-            info!("Listening for incoming connections...");
-
-            // Since incoming() is blocking, this thread will keep running even after drop() on the thread is called.
-            // There are platform-specific signals I can use to shutdown reads on the socket which will cause the
-            // incoming() iterator to return an error. For now, use Ctrl-C to terminate.
-            for stream in listener.incoming() {
-                match stream {
-                    Ok(stream) => {
-                        info!("Accepted a new connection.");
-
-                        if pool
-                            .execute(|| ConnectionHandler::handle_connection(stream))
-                            .is_err()
-                        {
-                            error!("Failed to create a worker thread to handle the connection.");
-                            // Continue processing incoming connections with other workers.
-                        }
-                    }
-                    Err(e) => {
-                        error!("Failed to accept: {}", e);
-                        // The error could be recoverable, but we'll just shutdown the connection handler for now.
-                        return;
-                    }
-                }
-            }
-        })
-    }
-
-    fn handle_connection(mut stream: TcpStream) {
-        let mut buffer = [0; 1024];
-        let mut read_bytes = 0;
-
-        // TODO: Accept >1024 bytes
-        match stream.read(&mut buffer) {
-            Ok(0) => return,
-            Ok(n) => {
-                read_bytes = n;
-            }
-            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
-            Err(e) => {
-                error!("Stream read failed: {}", e);
-                return;
-            }
-        }
-
-        let serialized = String::from_utf8_lossy(&buffer[..read_bytes]);
-
-        trace!("Request: {:?}", serialized);
-
-        let deserialized: Result<Command, _> = serde_json::from_str(&serialized);
-        match deserialized {
-            Ok(command) => {
-                ConnectionHandler::handle_command(command, stream);
-            }
-            Err(_) => {
-                error!("Invalid command received: {}", serialized);
-            }
-        }
-    }
-
-    fn handle_command(command: Command, mut stream: TcpStream) {
-        let mut buffer = [0; 1024];
-
-        match command {
-            Command::Echo(s) => {
-                let bytes = s.as_bytes();
-                buffer[..bytes.len()].copy_from_slice(bytes);
-            }
-        }
-
-        match stream.write_all(&buffer) {
-            Ok(_) => {}
-            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
-            Err(e) => {
-                error!("Stream write failed: {}", e);
-            }
-        }
-    }
-}
-
-// These tests shouldn't be included as a part of check-in tests yet. A spawned
-// thread will keep running because we haven't implemented a function to
-// terminate the listening socket. Instead, use Ctrl-C to terminate the test.
 #[cfg(test)]
 mod tests {
-    use super::{Command, Server};
+    use super::IPAService;
+    use crate::net::handler::Command;
     use std::io::prelude::*;
     use std::net::{SocketAddr, TcpStream};
 
@@ -181,12 +61,13 @@ mod tests {
 
     const ECHO_TEST: &str = "test";
 
-    fn start_server() -> Server {
-        Server::new(
+    fn start_server() {
+        IPAService::new(
             CONNECTION_HANDLER_HOST,
             CONNECTION_HANDLER_PORT,
             MAX_CONNECTION_COUNT,
         )
+        .start();
     }
 
     #[test]
@@ -194,7 +75,7 @@ mod tests {
     fn echo() {
         stderrlog::new().verbosity(5).init().unwrap();
 
-        let _server = start_server();
+        start_server();
 
         let addr: SocketAddr = format!("{}:{}", CONNECTION_HANDLER_HOST, CONNECTION_HANDLER_PORT)
             .parse()
@@ -218,7 +99,7 @@ mod tests {
     fn ignore_invalid_command() {
         stderrlog::new().verbosity(5).init().unwrap();
 
-        let _server = start_server();
+        start_server();
 
         let addr: SocketAddr = format!("{}:{}", CONNECTION_HANDLER_HOST, CONNECTION_HANDLER_PORT)
             .parse()

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -1,15 +1,43 @@
-use crate::net::Pool;
-use log::warn;
+use crate::net::{Job, Pool};
+use log::{error, info, trace, warn};
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Formatter};
+use std::io::prelude::*;
+use std::net::{SocketAddr, TcpListener, TcpStream};
+
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+enum Command {
+    Echo(String),
+}
+
+#[cfg(feature = "debug")]
+impl Debug for Command {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        f.write_str("Command::")?;
+        match self {
+            Self::Echo(_) => f.write_str("Echo"),
+        }
+    }
+}
 
 pub struct Server {
     connection_handler_thread: Pool,
+    connection_handler_addr: SocketAddr,
+    max_connection_count: usize,
 }
 
 impl Server {
     #[must_use]
-    pub fn new() -> Server {
+    pub fn new(host: &str, port: u16, max_connection_count: usize) -> Server {
+        let addr = format!("{}:{}", host, port)
+            .parse()
+            .expect("Invalid socket address.");
+
         Server {
             connection_handler_thread: Pool::new(1),
+            connection_handler_addr: addr,
+            max_connection_count,
         }
     }
 
@@ -27,32 +55,178 @@ impl Server {
     /// # Panics
     /// If the thread could not be spawned.
     fn start_connection_handler(&self) {
-        if let Err(e) = self.connection_handler_thread.execute(|| {
-            // listen
-            // read
-            // write
-        }) {
-            panic!("Could not start the connection handler: {}", e);
+        let handler =
+            ConnectionHandler::new(self.connection_handler_addr, self.max_connection_count);
+
+        if self
+            .connection_handler_thread
+            .execute(handler.start())
+            .is_err()
+        {
+            panic!("Could not start the connection handler thread.");
+        };
+    }
+}
+
+struct ConnectionHandler {
+    addr: SocketAddr,
+    pool_size: usize,
+}
+
+impl ConnectionHandler {
+    pub fn new(addr: SocketAddr, pool_size: usize) -> ConnectionHandler {
+        ConnectionHandler { addr, pool_size }
+    }
+
+    fn start(&self) -> Job {
+        let addr = self.addr;
+        let pool_size = self.pool_size;
+
+        Box::new(move || {
+            let listener = TcpListener::bind(addr).expect("Could not bind to the given address.");
+            let pool = Pool::new(pool_size);
+
+            info!("Listening for incoming connections...");
+
+            // Since incoming() is blocking, this thread will keep running even after drop() on the thread is called.
+            // There are platform-specific signals I can use to shutdown reads on the socket which will cause the
+            // incoming() iterator to return an error. For now, use Ctrl-C to terminate.
+            for stream in listener.incoming() {
+                match stream {
+                    Ok(stream) => {
+                        info!("Accepted a new connection.");
+
+                        if pool
+                            .execute(|| ConnectionHandler::handle_connection(stream))
+                            .is_err()
+                        {
+                            error!("Failed to create a worker thread to handle the connection.");
+                            // Continue processing incoming connections with other workers.
+                        }
+                    }
+                    Err(e) => {
+                        error!("Failed to accept: {}", e);
+                        // The error could be recoverable, but we'll just shutdown the connection handler for now.
+                        return;
+                    }
+                }
+            }
+        })
+    }
+
+    fn handle_connection(mut stream: TcpStream) {
+        let mut buffer = [0; 1024];
+        let mut read_bytes = 0;
+
+        // TODO: Accept >1024 bytes
+        match stream.read(&mut buffer) {
+            Ok(0) => return,
+            Ok(n) => {
+                read_bytes = n;
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => {
+                error!("Stream read failed: {}", e);
+                return;
+            }
+        }
+
+        let serialized = String::from_utf8_lossy(&buffer[..read_bytes]);
+
+        trace!("Request: {:?}", serialized);
+
+        let deserialized: Result<Command, _> = serde_json::from_str(&serialized);
+        match deserialized {
+            Ok(command) => {
+                ConnectionHandler::handle_command(command, stream);
+            }
+            Err(_) => {
+                error!("Invalid command received: {}", serialized);
+            }
+        }
+    }
+
+    fn handle_command(command: Command, mut stream: TcpStream) {
+        let mut buffer = [0; 1024];
+
+        match command {
+            Command::Echo(s) => {
+                let bytes = s.as_bytes();
+                buffer[..bytes.len()].copy_from_slice(bytes);
+            }
+        }
+
+        match stream.write_all(&buffer) {
+            Ok(_) => {}
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => {
+                error!("Stream write failed: {}", e);
+            }
         }
     }
 }
 
-impl Default for Server {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
+// These tests shouldn't be included as a part of check-in tests yet. A spawned
+// thread will keep running because we haven't implemented a function to
+// terminate the listening socket. Instead, use Ctrl-C to terminate the test.
 #[cfg(test)]
 mod tests {
-    use super::Server;
+    use super::{Command, Server};
+    use std::io::prelude::*;
+    use std::net::{SocketAddr, TcpStream};
+
+    const CONNECTION_HANDLER_HOST: &str = "127.0.0.1";
+    const CONNECTION_HANDLER_PORT: u16 = 7182;
+    const MAX_CONNECTION_COUNT: usize = 3;
+
+    const ECHO_TEST: &str = "test";
+
+    fn start_server() -> Server {
+        Server::new(
+            CONNECTION_HANDLER_HOST,
+            CONNECTION_HANDLER_PORT,
+            MAX_CONNECTION_COUNT,
+        )
+    }
 
     #[test]
-    fn no_panic() {
-        let mut server = Server::new();
+    #[ignore]
+    fn echo() {
+        stderrlog::new().verbosity(5).init().unwrap();
 
-        server.start();
+        let _server = start_server();
 
-        server.stop();
+        let addr: SocketAddr = format!("{}:{}", CONNECTION_HANDLER_HOST, CONNECTION_HANDLER_PORT)
+            .parse()
+            .unwrap();
+
+        for _ in 0..3 {
+            let mut stream = TcpStream::connect(addr).unwrap();
+
+            let command = serde_json::to_string(&Command::Echo(String::from("test"))).unwrap();
+            stream.write_all(command.as_bytes()).unwrap();
+
+            let mut buffer = [0; ECHO_TEST.len()];
+            stream.read_exact(&mut buffer).unwrap();
+
+            assert_eq!(buffer, ECHO_TEST.as_bytes());
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn ignore_invalid_command() {
+        stderrlog::new().verbosity(5).init().unwrap();
+
+        let _server = start_server();
+
+        let addr: SocketAddr = format!("{}:{}", CONNECTION_HANDLER_HOST, CONNECTION_HANDLER_PORT)
+            .parse()
+            .unwrap();
+
+        let mut stream = TcpStream::connect(addr).unwrap();
+
+        let command = String::from("invalid_command");
+        stream.write_all(command.as_bytes()).unwrap();
     }
 }

--- a/src/net/server.rs
+++ b/src/net/server.rs
@@ -1,19 +1,26 @@
-use crate::net::Thread;
+use crate::net::Pool;
+use log::warn;
 
 pub struct Server {
-    connection_handler_thread: Thread,
+    connection_handler_thread: Pool,
 }
 
 impl Server {
     #[must_use]
     pub fn new() -> Server {
         Server {
-            connection_handler_thread: Thread::new(),
+            connection_handler_thread: Pool::new(1),
         }
     }
 
     pub fn start(&self) {
         self.start_connection_handler();
+    }
+
+    pub fn stop(&mut self) {
+        if let Err(e) = self.connection_handler_thread.shutdown() {
+            warn!("Graceful shutdown failed: {}", e);
+        }
     }
 
     /// Spawns a new thread to handle incoming connections.
@@ -42,7 +49,10 @@ mod tests {
 
     #[test]
     fn no_panic() {
-        let server = Server::new();
+        let mut server = Server::new();
+
         server.start();
+
+        server.stop();
     }
 }

--- a/src/net/thread.rs
+++ b/src/net/thread.rs
@@ -14,7 +14,7 @@ struct Worker {
     thread: Option<thread::JoinHandle<()>>,
 }
 
-type Job = Box<dyn FnOnce() + Send + 'static>;
+pub type Job = Box<dyn FnOnce() + Send + 'static>;
 
 pub enum Message {
     NewJob(Job),

--- a/src/net/thread.rs
+++ b/src/net/thread.rs
@@ -14,7 +14,7 @@ struct Worker {
     thread: Option<thread::JoinHandle<()>>,
 }
 
-pub type Job = Box<dyn FnOnce() + Send + 'static>;
+type Job = Box<dyn FnOnce() + Send + 'static>;
 
 pub enum Message {
     NewJob(Job),


### PR DESCRIPTION
This is a stacked branch of my previous PR: [[Stacked Diff] Thread pool object for concurrent connections handling #19
](https://github.com/martinthomson/raw-ipa/pull/19)
New commits for this pull request begin at [dfad8b8](https://github.com/martinthomson/raw-ipa/commit/dfad8b8218909876c440f9b6515aecbab163f56d)

This commit adds a connection handler and basic networking IO.

1. `Server` spawns a new thread (`ConnectionHandler`) to create a `TcpListener` and a pool thread
2. For each accepted connection, `ConnectionHandler` will send the stream to any available thread
3. Each thread will handle the actual IO operation. Once the operation is completed, the thread returns to idle state

For testing purpose, I created `Echo` server command, which just returns whatever the server received.