### PR TITLE
simplify error definitions and discuss more robust error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = {version = "1.0", optional = true}
 sha2 = "0.9"
 stderrlog = {version = "0.5", optional = true}
 structopt = {version = "0.3", optional = true}
+thiserror = "1.0"
 
 [dev-dependencies]
 hex = "0.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,59 +1,35 @@
-#[derive(Debug)]
+use std::fmt::Debug;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
 pub enum Error {
+    #[error("already exists")]
     AlreadyExists,
+    #[error("internal")]
     Internal,
+    #[error("invalid id")]
     InvalidId,
+    #[error("invalid role")]
     InvalidRole,
+    #[error("not enough helpers")]
     NotEnoughHelpers,
+    #[error("not found")]
     NotFound,
-    RedisError(redis::RedisError),
+    #[error("problem during redis operation: {0}")]
+    RedisError(#[from] redis::RedisError),
+    #[error("too many helpers")]
     TooManyHelpers,
-    DeadThread(std::sync::mpsc::SendError<crate::net::Message>),
+    #[error("thread died: {0}")]
+    DeadThread(#[from] std::sync::mpsc::SendError<crate::net::Message>),
 
+    #[error("failed to decode hex: {0}")]
     #[cfg(feature = "cli")]
-    Hex(hex::FromHexError),
-    Io(std::io::Error),
+    Hex(#[from] hex::FromHexError),
+    #[error("problem during IO: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("failed to parse json: {0}")]
     #[cfg(feature = "enable-serde")]
-    Serde(serde_json::Error),
-}
-
-macro_rules! forward_errors {
-    {$($(#[$a:meta])* $t:path => $v:ident),* $(,)?} => {
-        $(
-            $(#[$a])*
-            impl From<$t> for Error {
-                fn from(e: $t) -> Self {
-                    Self::$v(e)
-                }
-            }
-        )*
-
-        impl std::error::Error for Error {
-            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-                match self {
-                    $( $(#[$a])* Self::$v(e) => Some(e), )*
-                    _ => None,
-                }
-            }
-        }
-    };
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{:?}", self)
-    }
-}
-
-forward_errors! {
-    std::sync::mpsc::SendError<crate::net::Message> => DeadThread,
-
-    #[cfg(feature = "cli")]
-    hex::FromHexError => Hex,
-    std::io::Error => Io,
-    #[cfg(feature = "enable-serde")]
-    serde_json::Error => Serde,
-    redis::RedisError => RedisError,
+    Serde(#[from] serde_json::Error),
 }
 
 pub type Res<T> = Result<T, Error>;


### PR DESCRIPTION
instead of implementing a custom macro to handle error enum, use [`thiserror` crate](https://docs.rs/thiserror/1.0.31/thiserror/) to simplify errors definition.

Not only will this remove a macro, it will make it easier to expand errors and error handling moving forward.

Particularly, we should consider sub-typing errors, either on a per-topic (ie, "parsing errors" vs "io errors"), or a per-module (ie, "the http module" vs "the pipeline module") basis.

What this could mean in practice is that the `main()` function will have a top-level `Error`, which breaks down into more specific errors.

If we delineate per-topic, we will use the `Error` type throughout the code base, and have heterogeneous error types that compose. this requires some extra work to allow for, say, a subtype of a subtype of error to be usable without fighting the type system. eg:

```rust
enum Error {
    ParseError(ParseError),
    IoError(IoError),
}
enum ParseError {
    JsonError(serde_json::Error)
}
enum IoError {
    Io(std::io::Error)
}

fn example() -> Result<(), Error> {
    // "?" does not compile since there is no `From<serde_json::Error> for Error`
    // only exists for `From<serde_json::Error> for ParseError`
    let v = serde_json::from_str("{ ...json_blob...}")?; 
    println!("{v}");
    Ok(())
}
```
we can get around this by defining the proper `From`, or by use of `.map_err(Into::into)`, but either way needs to be handled. This could result in a lot of extra code just to keep things ergonomic, but would be more flexible on where errors can be used.

alternatively, if we delineate per-module, we can use a different `Result` type per-module that has the module-specific version of the error:

```rust
// module http
enum HttpError {
    JsonError(serde_json::Error)
}

fn func_inside_http_mod() -> Result<(), HttpError> {
    ....
}

// module pipeline
enum PipelineError {
    Io(std::io::Error)
}

fn func_inside_pipeline_mod() -> Result<(), PipelineError> {
    ...
}

// module lib (top level)
enum Error {
    HttpError(http::HttpError),
    PipelineError(pipeline::PipelineError),
}

fn main() -> Result<(), Error> {
    // both "?" work because there exists a `From<HttpError> for Error` and
    // `From<PipelineError> for Error`
    let http_res = func_inside_http_mod()?;
    let pipeline_res = func_inside_pipeline_mod()?;
    println("{http_res}, {pipeline_res}");
    Ok(())
}
```

In this case, errors are strictly hierarchical, mapping directly onto modules. This keeps things simpler, but may result in some overlapping errors; for instance, it could be the case that both `http` and `pipeline` need to parse some json, in which case both must have their own definitions of `JsonError`. This may actually end up being a positive, because we get an ad-hoc stack trace, in that we can differentiate between a `pipeline::PipelineError::JsonError` and a `http::HttpError::JsonError`.

based on these two ideas, and with some discussion with Alex Koshalev (thanks for introducing the idea of per-module based errors), I think we should gravitate more towards the per-module errors.