### PR TITLE
Enable clippy rule clone_on_ref_ptr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::clone_on_ref_ptr)]
+
 #[cfg(feature = "cli")]
 pub mod cli;
 pub mod error;


### PR DESCRIPTION
It is disabled by default.
https://rust-lang.github.io/rust-clippy/master/#clone_on_ref_ptr
Motivated by https://github.com/rust-lang/rfcs/issues/2588