### PR TITLE
Migrate to `tracing` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 
 [features]
 default = ["debug", "cli"]
-cli = ["enable-serde", "stderrlog", "structopt", "web-app"]
+cli = ["enable-serde", "structopt", "web-app", "tracing-subscriber"]
 debug = ["hex"]
 enable-serde = ["serde", "serde_json", "rust-elgamal/enable-serde"]
-web-app = ["tokio", "axum", "axum-server", "hyper", "hyper-tls"]
+web-app = ["tokio", "axum", "axum-server", "hyper", "hyper-tls", "tower-http"]
 self-signed-certs = ["hyper-tls"]
 
 [dependencies]
@@ -27,14 +27,18 @@ serde = {version = "1.0", optional = true}
 serde_json = {version = "1.0", optional = true}
 # rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, so pin this
 sha2 = "0.9"
-stderrlog = {version = "0.5", optional = true}
 structopt = {version = "0.3", optional = true}
 thiserror = "1.0"
+tracing = "0.1.35"
 tokio = { version = "1.19.2", optional = true, features = ["rt", "rt-multi-thread", "macros"] }
 axum = { version = "0.5.7", optional = true, features = ["http2"] }
 hyper = { version = "0.14.19", optional = true, features = ["client", "h2"] }
 hyper-tls = { version = "0.5.0", optional = true }
 axum-server = { version = "0.4.0", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
+tracing-subscriber = { version = "0.3.14", optional = true }
+tower-http = { version = "0.3.4", optional = true, features = ["trace"] }
+
+
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,33 +13,30 @@ web-app = ["tokio", "axum", "axum-server", "hyper", "hyper-tls", "tower-http"]
 self-signed-certs = ["hyper-tls"]
 
 [dependencies]
+axum = { version = "0.5.7", optional = true, features = ["http2"] }
+axum-server = { version = "0.4.0", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
 # rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, not 0.10
 digest = "0.9"
-hex = {version = "0.4", optional = true}
+hex = { version = "0.4", optional = true }
 # rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, so pin this
 hkdf = "0.11"
-log = "0.4"
-rand_core = "0.6"
-rand = "0.8"
-redis = "0.21.5"
-rust-elgamal = "0.4"
-serde = {version = "1.0", optional = true}
-serde_json = {version = "1.0", optional = true}
-# rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, so pin this
-sha2 = "0.9"
-structopt = {version = "0.3", optional = true}
-thiserror = "1.0"
-tracing = "0.1.35"
-tokio = { version = "1.19.2", optional = true, features = ["rt", "rt-multi-thread", "macros"] }
-axum = { version = "0.5.7", optional = true, features = ["http2"] }
 hyper = { version = "0.14.19", optional = true, features = ["client", "h2"] }
 hyper-tls = { version = "0.5.0", optional = true }
-axum-server = { version = "0.4.0", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
-tracing-subscriber = { version = "0.3.14", optional = true }
+log = "0.4"
+rand = "0.8"
+rand_core = "0.6"
+redis = "0.21.5"
+rust-elgamal = "0.4"
+serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
+# rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, so pin this
+sha2 = "0.9"
+structopt = { version = "0.3", optional = true }
+thiserror = "1.0"
+tokio = { version = "1.19.2", optional = true, features = ["rt", "rt-multi-thread", "macros"] }
 tower-http = { version = "0.3.4", optional = true, features = ["trace"] }
-
-
-
+tracing = "0.1.35"
+tracing-subscriber = { version = "0.3.14", optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -1,11 +1,11 @@
 use std::error::Error;
 
 use hyper::http::uri::Scheme;
-use log::info;
 use raw_ipa::cli::Verbosity;
 use raw_ipa::net::{bind_mpc_helper_server, BindTarget};
 use std::net::SocketAddr;
 use structopt::StructOpt;
+use tracing::info;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "mpc-helper", about = "CLI to start an MPC helper endpoint")]

--- a/src/bin/ua.rs
+++ b/src/bin/ua.rs
@@ -1,4 +1,3 @@
-use log::{debug, error, info, trace, warn};
 use raw_ipa::cli::{HelperArgs, StringN, Verbosity};
 use raw_ipa::{helpers::Helpers, user::User};
 use std::fs;
@@ -6,6 +5,7 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::str::FromStr;
 use structopt::StructOpt;
+use tracing::{debug, error, info, trace, warn};
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "ua", about = "Functions for IPA User Agents")]

--- a/src/cli/verbosity.rs
+++ b/src/cli/verbosity.rs
@@ -1,5 +1,8 @@
-use log::info;
+use std::io;
 use structopt::StructOpt;
+use tracing::metadata::LevelFilter;
+use tracing::{info, Level};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Debug, StructOpt)]
 pub struct Verbosity {
@@ -12,18 +15,29 @@ pub struct Verbosity {
     verbose: usize,
 }
 
+fn from_verbosity(quiet: bool, verbose: usize) -> LevelFilter {
+    if quiet {
+        LevelFilter::OFF
+    } else {
+        LevelFilter::from_level(match verbose {
+            0 => Level::ERROR,
+            1 => Level::WARN,
+            2 => Level::INFO,
+            3 => Level::DEBUG,
+            _ => Level::TRACE,
+        })
+    }
+}
+
 impl Verbosity {
     pub fn setup_logging(&self) {
-        stderrlog::new()
-            .quiet(self.quiet)
-            .verbosity(self.verbose)
-            .timestamp(stderrlog::Timestamp::Off)
-            .init()
-            .unwrap_or_else(|e| {
-                if !self.quiet {
-                    eprintln!("unable to configure logging: {:?}", e);
-                }
-            });
-        info!("Logging setup at level {}", self.verbose);
+        let filter_layer = from_verbosity(self.quiet, self.verbose);
+        let fmt_layer = fmt::layer().without_time().with_writer(io::stderr);
+
+        tracing_subscriber::registry()
+            .with(filter_layer)
+            .with(fmt_layer)
+            .init();
+        info!("Logging setup at level {}", filter_layer);
     }
 }

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -10,6 +10,7 @@ use axum_server::{tls_rustls::RustlsConfig, Handle};
 use hyper::StatusCode;
 use thiserror::Error;
 use tokio::task::JoinHandle;
+use tower_http::trace::TraceLayer;
 
 mod handlers;
 
@@ -45,7 +46,9 @@ pub enum BindTarget {
 /// Starts a new instance of MPC helper and binds it to a given target.
 /// Returns a socket it is listening to and the join handle of the web server running.
 pub async fn bind(target: BindTarget) -> (SocketAddr, JoinHandle<()>) {
-    let svc = router().into_make_service();
+    let svc = router()
+        .layer(TraceLayer::new_for_http())
+        .into_make_service();
     let handle = Handle::new();
 
     let task_handle = match target {

--- a/src/net/thread.rs
+++ b/src/net/thread.rs
@@ -1,7 +1,7 @@
-use log::{error, info, warn};
 use std::fmt::{Debug, Formatter};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
+use tracing::{error, info, warn};
 
 use crate::error::Res;
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -3,7 +3,6 @@ use crate::error::{Error, Res};
 use crate::report::{EncryptedMatchkeys, EventReport};
 use crate::threshold::{Ciphertext, EncryptionKey as ThresholdEncryptionKey, RistrettoPoint};
 use hkdf::Hkdf;
-use log::trace;
 use rand::{thread_rng, RngCore};
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
@@ -13,6 +12,7 @@ use std::collections::HashMap;
 use std::fs;
 #[cfg(feature = "enable-serde")]
 use std::path::{Path, PathBuf};
+use tracing::trace;
 
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct User {


### PR DESCRIPTION
## Overview

Tracing crate has all features we're using currently (print to stderr, verbosity, format) and is required to instrument MPC helpers with telemetry required to understand the performance of it and different protocols we'll be experimenting with.

This change also adds some pretty basic tracing of HTTP requests by using `tower-http` crate.

`stderrlog` crate is removed as we no longer need to use it. Besides that, it has a security advisory against it

```
Crate:     time
Version:   0.1.44
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.44
└── chrono 0.4.19
    └── stderrlog 0.5.3
        └── raw-ipa 0.1.0

error: 1 vulnerability found!
```


## Testing

terminal window 1

```bash
 cargo run --features self-signed-certs --bin helper -- -s https -p 3000 -vvv                                                                                                                                                           helper-service 6d5c2f5
    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
     Running `target/debug/helper -s https -p 3000 -vvv`
 INFO raw_ipa::cli::verbosity: Logging setup at level debug
 INFO helper: listening to https://127.0.0.1:3000
DEBUG rustls::server::hs: decided upon suite TLS13_AES_256_GCM_SHA384
DEBUG hyper::proto::h1::io: parsed 5 headers
DEBUG hyper::proto::h1::conn: incoming body is empty
DEBUG request{method=GET uri=/echo?foo=bar version=HTTP/1.1}: tower_http::trace::on_request: started processing request
DEBUG request{method=GET uri=/echo?foo=bar version=HTTP/1.1}: tower_http::trace::on_response: finished processing request latency=0 ms status=200
DEBUG hyper::proto::h1::io: flushed 270 bytes
DEBUG hyper::proto::h1::conn: read eof
DEBUG rustls::conn: Sending warning alert CloseNotify
```

terminal window 2

```bash
wget -q -nv "https://127.0.0.1:3000/echo?foo=bar" --no-check-certificate -O -
```

