### PR TITLE
Python script to start helper servers

### DIFF
--- a/scripts/start-helpers.py
+++ b/scripts/start-helpers.py
@@ -1,0 +1,61 @@
+import argparse
+import subprocess
+from select import select
+
+
+def start_helpers(exec, count, port, timeout=0.1):
+    commands = [
+        [exec, '-vvv',  '-p', str(port + i)] for i in range(count)
+    ]
+
+    procs = [subprocess.Popen(cmd,
+                              stdout=subprocess.PIPE,
+                              bufsize=1,
+                              universal_newlines=True,
+                              ) for cmd in commands]
+
+    while procs:
+        for p in procs:
+            # remove terminated processes
+            if p.poll() is not None:
+                print(p.stdout.read(), end='')
+                p.stdout.close()
+                procs.remove(p)
+
+        # wait and print the output
+        rlist = select([p.stdout for p in procs], [], [], timeout)[0]
+        for f in rlist:
+            print(f.readline(), end='')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Start multiple helpers serializing all outputs to stdout")
+
+    parser.add_argument(
+        '-t', '--timeout', type=float, metavar="SEC", default=0.1,
+        help='specify the select timeout for sync',
+    )
+    parser.add_argument(
+        '-e', '--executable', type=str, metavar="path", required=True, help="helper server executable path"
+    )
+    parser.add_argument(
+        '-n', '--number', type=int, metavar="count", default=3, help="Number of helpers to start. Default = 3"
+    )
+    parser.add_argument(
+        '-p', '--port', type=int, metavar="port", default=12345, help=(
+            "Helper servers' starting port number. Default = 12345.\n"
+            "E.g. \"-p 12345 -n 3\" will try to bind to 12345, 12346, 12347."
+        )
+    )
+
+    # Handle the input from the command line
+    try:
+        args = parser.parse_args()
+        start_helpers(exec=args.executable,
+                      count=args.number,
+                      port=args.port,
+                      timeout=args.timeout,)
+        parser.exit(0)
+    except Exception as e:
+        parser.error(str(e))


### PR DESCRIPTION
## Overview
This python script launches multiple [helper] CLI (MPC server) instances bound on given ports. This is to be used together with a client CLI to test out IPA protocols (#36).

## Example
* Launch 3 helper instances on ports from 9876 to 9878 (and Ctrl-C to terminate all instances)
```
❯ python3 ./scripts/start-helpers.py -e ./target/debug/helper -p 9876 -n 3
 INFO raw_ipa::cli::verbosity: Logging setup at level debug
 INFO raw_ipa::cli::verbosity: Logging setup at level debug
 INFO raw_ipa::cli::verbosity: Logging setup at level debug
 INFO helper: listening to http://127.0.0.1:9878
 INFO helper: listening to http://127.0.0.1:9877
 INFO helper: listening to http://127.0.0.1:9876
^C
Traceback (most recent call last):
  File "/Users/taiki/src/raw-ipa/./scripts/start-helpers.py", line 55, in <module>
    start_helpers(exec=args.executable,
  File "/Users/taiki/src/raw-ipa/./scripts/start-helpers.py", line 26, in start_helpers
    rlist = select([p.stdout for p in procs], [], [], timeout)[0]
KeyboardInterrupt
```