### PR TITLE
Introduce metrics to the system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 
 [features]
 default = ["debug", "cli"]
-cli = ["enable-serde", "structopt", "web-app", "tracing-subscriber"]
+cli = ["comfy-table", "enable-serde", "metrics-tracing-context", "metrics-util", "structopt", "tracing-subscriber", "web-app"]
 debug = ["hex"]
 enable-serde = ["serde", "serde_json", "rust-elgamal/enable-serde"]
-web-app = ["tokio", "tokio-stream", "axum", "axum-server", "hyper", "hyper-tls", "tower-http"]
+web-app = ["tokio", "tokio-stream", "axum", "axum-server", "hyper", "hyper-tls", "tower", "tower-http"]
 self-signed-certs = ["hyper-tls"]
 test-fixture = []
 
@@ -19,6 +19,7 @@ async-trait = "0.1.56"
 axum = { version = "0.5.7", optional = true, features = ["http2"] }
 axum-server = { version = "0.4.0", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
 byteorder = "1"
+comfy-table = { version = "6.0.0", optional = true }
 # rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, not 0.10
 digest = "0.9"
 futures = "0.3.21"
@@ -29,7 +30,9 @@ hex = { version = "0.4", optional = true }
 hkdf = "0.11"
 hyper = { version = "0.14.19", optional = true, features = ["client", "h2"] }
 hyper-tls = { version = "0.5.0", optional = true }
-log = "0.4"
+metrics = "0.19.0"
+metrics-tracing-context = { version = "0.11.0", optional = true }
+metrics-util = { version = "0.13.0", optional = true }
 pin-project = "1.0.11"
 rand = "0.8"
 rand_core = "0.6"
@@ -44,6 +47,7 @@ structopt = { version = "0.3", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.19.2", optional = true, features = ["rt", "rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1.9", optional = true }
+tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.3.4", optional = true, features = ["trace"] }
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.14", optional = true }

--- a/src/bin/ipa_bench/cmd.rs
+++ b/src/bin/ipa_bench/cmd.rs
@@ -2,7 +2,6 @@ use crate::sample::Sample;
 
 use super::gen_events::generate_events;
 
-use log::{debug, error, info};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use raw_ipa::cli::Verbosity;
@@ -10,6 +9,7 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::{io, process};
 use structopt::StructOpt;
+use tracing::{debug, error, info};
 
 const DEFAULT_EVENT_GEN_COUNT: u32 = 100_000;
 

--- a/src/bin/ipa_bench/gen_events.rs
+++ b/src/bin/ipa_bench/gen_events.rs
@@ -1,6 +1,5 @@
 use super::sample::Sample;
 use byteorder::WriteBytesExt;
-use log::{debug, info, trace};
 use rand::{CryptoRng, Rng, RngCore};
 use rand_distr::num_traits::ToPrimitive;
 use rand_distr::{Bernoulli, Distribution};
@@ -11,6 +10,8 @@ use raw_ipa::helpers::models::{
 use serde::{Deserialize, Serialize};
 use std::io;
 use std::time::Duration;
+use tracing::{debug, info};
+use tracing::log::trace;
 
 // 0x1E. https://datatracker.ietf.org/doc/html/rfc7464
 const RECORD_SEPARATOR: u8 = 30;

--- a/src/bin/ipa_bench/gen_events.rs
+++ b/src/bin/ipa_bench/gen_events.rs
@@ -10,8 +10,7 @@ use raw_ipa::helpers::models::{
 use serde::{Deserialize, Serialize};
 use std::io;
 use std::time::Duration;
-use tracing::{debug, info};
-use tracing::log::trace;
+use tracing::{debug, info, trace};
 
 // 0x1E. https://datatracker.ietf.org/doc/html/rfc7464
 const RECORD_SEPARATOR: u8 = 30;

--- a/src/bin/ipa_bench/ipa_bench.rs
+++ b/src/bin/ipa_bench/ipa_bench.rs
@@ -7,6 +7,6 @@ use structopt::StructOpt;
 
 fn main() {
     let args = cmd::Args::from_args();
-    args.common.logging.setup_logging();
+    let _handle = args.common.logging.setup_logging();
     args.cmd.dispatch(&args.common);
 }

--- a/src/bin/test_mpc.rs
+++ b/src/bin/test_mpc.rs
@@ -19,7 +19,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::from_args();
-    args.logging.setup_logging();
+    let _handle = args.logging.setup_logging();
 
     // TODO: Start MPC helpers and discover
     let client = Client::new(args.uri.as_str());

--- a/src/cli/metric_collector.rs
+++ b/src/cli/metric_collector.rs
@@ -1,0 +1,44 @@
+use crate::cli::Metrics;
+use metrics_tracing_context::TracingContextLayer;
+use metrics_util::debugging::{DebuggingRecorder, Snapshotter};
+use metrics_util::layers::Layer;
+use std::io::stderr;
+use std::thread;
+
+/// Collects metrics using `DebuggingRecorder` and dumps them to `stderr` when dropped.
+pub struct CollectorHandle {
+    snapshotter: Snapshotter,
+}
+
+///
+/// Initializes this collector by installing `DebuggingRecorder` to keep track of metrics
+/// emitted from different parts of the app.
+///
+/// ## Panics
+/// Panics if metric recorder has already been set
+#[must_use]
+pub fn install_collector() -> CollectorHandle {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+
+    // use span fields as dimensions for metric
+    let recorder = TracingContextLayer::all().layer(recorder);
+    metrics::set_boxed_recorder(Box::new(recorder))
+        .expect("Metric recorder has been installed already");
+
+    // register metrics
+    crate::telemetry::metrics::register();
+
+    CollectorHandle { snapshotter }
+}
+
+impl Drop for CollectorHandle {
+    fn drop(&mut self) {
+        if !thread::panicking() {
+            let stats = Metrics::from_snapshot(self.snapshotter.snapshot());
+            stats
+                .print(&mut stderr())
+                .expect("Failed to dump metrics to stderr");
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,11 @@
 mod hexarg;
+mod metric_collector;
+mod stats;
 mod stringn;
 mod verbosity;
 
+pub use self::stats::{CounterDetails, Metrics};
 pub use hexarg::HexArg;
+pub use metric_collector::{install_collector, CollectorHandle};
 pub use stringn::StringN;
 pub use verbosity::Verbosity;

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -47,7 +47,7 @@ impl CounterDetails {
                 .entry(label_key)
                 .or_insert_with(HashMap::new);
 
-            *dimension_values.entry(label_val).or_insert_with(|| 0) += val;
+            *dimension_values.entry(label_val).or_insert(0) += val;
         }
 
         self.total_value += val;
@@ -97,8 +97,6 @@ impl Metrics {
         metrics_table.set_header(vec!["metric", "description", "value", "dimensions"]);
 
         for (key_name, counter_stats) in &self.counters {
-            let key_name = key_name;
-
             let mut dim_cell_content = String::new();
             for (dim, values) in counter_stats.iter() {
                 dim_cell_content += format!("{dim}\n").as_str();

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -1,0 +1,122 @@
+use std::collections::hash_map::Iter;
+use std::collections::HashMap;
+use std::io::Write;
+
+use comfy_table::Table;
+use metrics::{KeyName, SharedString};
+
+use metrics_util::debugging::{DebugValue, Snapshot};
+use metrics_util::{CompositeKey, MetricKind};
+
+/// Simple counter stats
+#[derive(Debug, Default)]
+pub struct CounterDetails {
+    total_value: u64,
+    dimensions: HashMap<SharedString, HashMap<SharedString, u64>>,
+}
+
+/// Container for metrics, their descriptions and values they've accumulated.
+/// Currently only support `Counter`, however `Gauge` and `Histogram` can be easily added later.
+///
+/// An example of a counter layout inside this struct
+/// `counter_name` -> (`total_value`: X, `dimensions`: (Y -> X1, Y -> X2))
+/// total value represents the counter value, i.e. how many times this value was incremented
+/// through the duration of the program, regardless of the circumstances (dimensions).
+///
+/// Each counter may have multiple dimensions. A dimension is a simple key-value pair that adds
+/// some extra information to the counter and can be used to filter out values. For example,
+/// adding `http_method` dimension allows to have a breakdown for values incremented during GET,PUT
+/// or POST requests.
+///
+/// X1 and X2 cannot be greater than X, but these values may overlap, i.e. X1 + X2 >= X
+pub struct Metrics {
+    counters: HashMap<KeyName, CounterDetails>,
+    metric_description: HashMap<KeyName, &'static str>,
+}
+
+impl CounterDetails {
+    pub fn add(&mut self, key: &CompositeKey, val: &DebugValue) {
+        let val = match val {
+            DebugValue::Counter(v) => v,
+            _ => unreachable!(),
+        };
+        for label in key.key().labels() {
+            let (label_key, label_val) = label.clone().into_parts();
+            let dimension_values = self
+                .dimensions
+                .entry(label_key)
+                .or_insert_with(HashMap::new);
+
+            *dimension_values.entry(label_val).or_insert_with(|| 0) += val;
+        }
+
+        self.total_value += val;
+    }
+
+    #[must_use]
+    pub fn iter(&self) -> Iter<'_, SharedString, HashMap<SharedString, u64>> {
+        self.dimensions.iter()
+    }
+}
+
+impl Metrics {
+    #[must_use]
+    pub fn from_snapshot(snapshot: Snapshot) -> Self {
+        let mut this = Metrics {
+            counters: HashMap::new(),
+            metric_description: HashMap::new(),
+        };
+
+        let snapshot = snapshot.into_vec();
+        for (ckey, _, descr, val) in snapshot {
+            let (key_name, _) = ckey.key().clone().into_parts();
+            let entry = this
+                .counters
+                .entry(key_name.clone())
+                .or_insert_with(CounterDetails::default);
+
+            if let Some(descr) = descr {
+                this.metric_description.insert(key_name, descr);
+            }
+
+            match ckey.kind() {
+                MetricKind::Counter => entry.add(&ckey, &val),
+                MetricKind::Gauge | MetricKind::Histogram => unimplemented!(),
+            }
+        }
+
+        this
+    }
+
+    /// Dumps the stats to the provided Write interface.
+    ///
+    /// ## Errors
+    /// returns an IO error if it fails to write to the provided writer.
+    pub fn print(&self, w: &mut impl Write) -> Result<(), std::io::Error> {
+        let mut metrics_table = Table::new();
+        metrics_table.set_header(vec!["metric", "description", "value", "dimensions"]);
+
+        for (key_name, counter_stats) in &self.counters {
+            let key_name = key_name;
+
+            let mut dim_cell_content = String::new();
+            for (dim, values) in counter_stats.iter() {
+                dim_cell_content += format!("{dim}\n").as_str();
+                for (dim_value, &counter_val) in values {
+                    dim_cell_content += format!("{dim_value} = {counter_val}\n").as_str();
+                }
+            }
+
+            metrics_table.add_row(vec![
+                key_name.as_str(),
+                self.metric_description.get(key_name).unwrap_or(&""),
+                counter_stats.total_value.to_string().as_str(),
+                dim_cell_content.as_str(),
+            ]);
+        }
+
+        writeln!(w, "{metrics_table}")?;
+
+        Ok(())
+    }
+}

--- a/src/cli/verbosity.rs
+++ b/src/cli/verbosity.rs
@@ -37,11 +37,7 @@ impl Verbosity {
             .init();
 
         let handle = LoggingHandle {
-            metrics_handle: if self.quiet {
-                None
-            } else {
-                Some(install_collector())
-            },
+            metrics_handle: (!self.quiet).then(install_collector),
         };
 
         info!("Logging setup at level {}", filter_layer);

--- a/src/cli/verbosity.rs
+++ b/src/cli/verbosity.rs
@@ -1,7 +1,11 @@
+use metrics_tracing_context::MetricsLayer;
+
 use std::io::stderr;
+
+use crate::cli::install_collector;
+use crate::cli::metric_collector::CollectorHandle;
 use structopt::StructOpt;
-use tracing::metadata::LevelFilter;
-use tracing::{info, Level};
+use tracing::{info, metadata::LevelFilter, Level};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Debug, StructOpt)]
@@ -15,16 +19,34 @@ pub struct Verbosity {
     verbose: usize,
 }
 
+pub struct LoggingHandle {
+    #[allow(dead_code)] // we care about handle's drop semantic so it is ok to not read it
+    metrics_handle: Option<CollectorHandle>,
+}
+
 impl Verbosity {
-    pub fn setup_logging(&self) {
+    #[must_use]
+    pub fn setup_logging(&self) -> LoggingHandle {
         let filter_layer = self.level_filter();
         let fmt_layer = fmt::layer().without_time().with_writer(stderr);
 
         tracing_subscriber::registry()
             .with(self.level_filter())
             .with(fmt_layer)
+            .with(MetricsLayer::new())
             .init();
+
+        let handle = LoggingHandle {
+            metrics_handle: if self.quiet {
+                None
+            } else {
+                Some(install_collector())
+            },
+        };
+
         info!("Logging setup at level {}", filter_layer);
+
+        handle
     }
 
     fn level_filter(&self) -> LevelFilter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod prss;
 pub mod replicated_secret_sharing;
 pub mod securemul;
 pub mod shamir;
+pub mod telemetry;
 
 #[cfg(any(test, feature = "test-fixture"))]
 pub mod test_fixture;

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,0 +1,48 @@
+pub mod metrics {
+    use metrics::describe_counter;
+    use metrics::Unit;
+
+    pub const REQUESTS_RECEIVED: &str = "requests.received";
+
+    /// Registers metrics used in the system with the metrics recorder.
+    ///
+    /// ## Panics
+    /// Panic if there is no recorder installed
+    pub fn register() {
+        assert!(
+            matches!(metrics::try_recorder(), Some(_)),
+            "metrics recorder must be installed before metrics can be described"
+        );
+
+        describe_counter!(
+            REQUESTS_RECEIVED,
+            Unit::Count,
+            "Total number of requests received by the web server"
+        );
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub fn get_counter_value(
+        snapshot: metrics_util::debugging::Snapshot,
+        metric_name: &'static str,
+    ) -> Option<u64> {
+        use metrics_util::debugging::DebugValue;
+        use metrics_util::MetricKind;
+
+        let snapshot = snapshot.into_vec();
+
+        for (key, _unit, _, val) in snapshot {
+            if key.kind() == MetricKind::Counter
+                && key.key().name().eq_ignore_ascii_case(metric_name)
+            {
+                match val {
+                    DebugValue::Counter(v) => return Some(v),
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        None
+    }
+}


### PR DESCRIPTION
## Overview

There are currently two metrics implementations that most of the crates use:
* [OpenTelemetry](https://docs.rs/opentelemetry/latest/opentelemetry/#metrics)
* [Metrics](https://docs.rs/metrics/0.19.0/metrics/)

Both provide similar API that allows creating counters, gauges and histograms.
However, there seem to be a warning that OpenTelemetry implementation is not stable.
Also, OpenTelemetry crate is more than just metrics, it also provides tracing API,
which may shadow `tracing` if pulled in scope.

Because of these reasons, this change suggests to use `Metrics` crate. However, it is
likely that we would need to start using OpenTelemetry at some point because it
provides integration with many open-source and third-party metric/trace collectors
and visualization tools. I don't believe we will have to rewrite IPA implementation
to do that, because it is possible to integrate tracing with OpenTelemetry using
[tracing-opentelemetry](https://docs.rs/tracing-opentelemetry/0.17.4/tracing_opentelemetry/)
crate and integrate `Metrics` by creating a `Recorder` that just dumps everything
to `OpenTelemetry` sink

## Description of the change

* Add `Metrics` crate as dependency
* Modify tower tracing layer to emit `requests.received` metric
* Unit tests for the above
* A toy implementation of metrics sinkkk for CLI that dumps everything to stderr

## Testing

```bash
cargo run --features self-signed-certs --bin helper -- -s https -p 3000 -vvv
```

```bash
wget -q -nv "https://127.0.0.1:3000/echo?foo=bar" --no-check-certificate -O -
wget -q -nv "https://127.0.0.1:3000/echo?anotherfoo=anotherbar" --no-check-certificate -O -
```


```bash
DEBUG rustls::server::hs: decided upon suite TLS13_AES_256_GCM_SHA384
DEBUG hyper::proto::h1::io: parsed 5 headers
DEBUG hyper::proto::h1::conn: incoming body is empty
DEBUG request{method=GET uri=/echo?foo=bar version=HTTP/1.1}: tower_http::trace::on_response: finished processing request latency=0 ms status=200
DEBUG hyper::proto::h1::io: flushed 270 bytes
DEBUG hyper::proto::h1::conn: read eof
DEBUG rustls::conn: Sending warning alert CloseNotify
DEBUG rustls::server::hs: decided upon suite TLS13_AES_256_GCM_SHA384
DEBUG hyper::proto::h1::io: parsed 5 headers
DEBUG hyper::proto::h1::conn: incoming body is empty
DEBUG request{method=GET uri=/echo?anotherfoo=anotherbar version=HTTP/1.1}: tower_http::trace::on_response: finished processing request latency=0 ms status=200
DEBUG hyper::proto::h1::io: flushed 284 bytes
DEBUG hyper::proto::h1::conn: read eof
DEBUG rustls::conn: Sending warning alert CloseNotify

+-------------------+-----------------------------------------------------+-------+---------------------------------+
| metric            | description                                         | value | dimensions                      |
+===================================================================================================================+
| requests.received | Total number of requests received by the web server | 2     | uri                             |
|                   |                                                     |       | /echo?foo=bar = 1               |
|                   |                                                     |       | /echo?anotherfoo=anotherbar = 1 |
|                   |                                                     |       | method                          |
|                   |                                                     |       | GET = 2                         |
|                   |                                                     |       | version                         |
|                   |                                                     |       | HTTP/1.1 = 2                    |
|                   |                                                     |       |                                 |
+-------------------+-----------------------------------------------------+-------+---------------------------------+
```