### PR TITLE
Cargo.toml housekeeping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "raw-ipa"
 version = "0.1.0"
-rust-version = "1.57.0"
+rust-version = "1.62.0"
 edition = "2021"
 
 [features]
@@ -27,11 +27,9 @@ hkdf = "0.11"
 hyper = { version = "0.14.19", optional = true, features = ["client", "h2"] }
 hyper-tls = { version = "0.5.0", optional = true }
 log = "0.4"
-# This is stupid, but we have packages that want this old interface
-# those have to use the same RNG as packages that want the new interface.
-old_rand_core = { package = "rand_core", version = "0.5", default-features = false }
 rand = "0.8"
 rand_core = "0.6"
+rand_distr = "0.4.3"
 redis = "0.21.5"
 rust-elgamal = "0.4"
 serde = { version = "1.0", optional = true }
@@ -44,8 +42,7 @@ tokio = { version = "1.19.2", optional = true, features = ["rt", "rt-multi-threa
 tower-http = { version = "0.3.4", optional = true, features = ["trace"] }
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.14", optional = true }
-x25519-dalek = "1"
-rand_distr = "0.4.3"
+x25519-dalek = "2.0.0-pre.1"
 
 [dev-dependencies]
 hex = "0.4"

--- a/src/prss.rs
+++ b/src/prss.rs
@@ -132,9 +132,8 @@ pub struct KeyExchange {
 
 impl KeyExchange {
     pub fn new<R: RngCore + CryptoRng>(r: &mut R) -> Self {
-        let mut r = rng::Adapter::from(r);
         Self {
-            sk: EphemeralSecret::new(&mut r),
+            sk: EphemeralSecret::new(r),
         }
     }
 
@@ -229,39 +228,6 @@ impl From<Generator> for BitGenerator {
     fn from(g: Generator) -> Self {
         Self { g, i: 0, v: 0 }
     }
-}
-
-// x25519-dalek uses an old version of the rand_core crate.
-// This is incompatible with the rand crate that the rest of the project uses,
-// but it is basically the same.  This adapter manages that.
-mod rng {
-    use old_rand_core::{CryptoRng as OldCryptoRng, Error as OldError, RngCore as OldRngCore};
-    use rand_core::{CryptoRng, RngCore};
-
-    pub struct Adapter<'a, R>(&'a mut R);
-
-    impl<'a, R: RngCore + CryptoRng> From<&'a mut R> for Adapter<'a, R> {
-        fn from(r: &'a mut R) -> Self {
-            Self(r)
-        }
-    }
-
-    impl<R: RngCore> OldRngCore for Adapter<'_, R> {
-        fn fill_bytes(&mut self, dest: &mut [u8]) {
-            self.0.fill_bytes(dest);
-        }
-        fn next_u32(&mut self) -> u32 {
-            self.0.next_u32()
-        }
-        fn next_u64(&mut self) -> u64 {
-            self.0.next_u64()
-        }
-        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), OldError> {
-            self.0.try_fill_bytes(dest).map_err(OldError::new)
-        }
-    }
-
-    impl<R: CryptoRng> OldCryptoRng for Adapter<'_, R> {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
* x25519-dalek: upgrade to v2 as it uses rand 0.6 and we don't need rng adapter anymore
* bump up rust compiler version to 1.62
* sort dependencies