### PR TITLE
Modify event structures

### DIFF
--- a/src/bin/ipa_bench/gen_events.rs
+++ b/src/bin/ipa_bench/gen_events.rs
@@ -109,7 +109,7 @@ pub enum Event {
 }
 
 struct GenEventParams {
-    devices: u8,
+    matchkeys: u8,
     impressions: u8,
     conversions: u8,
     epoch: Epoch,
@@ -153,10 +153,10 @@ pub fn generate_events<R: RngCore + CryptoRng, W: io::Write>(
         debug!("CVR: {}", cvr);
 
         for _ in 0..reach {
-            // # of devices == # of matchkeys
-            // Hard code this number to 1 as we only have a solution for one match key.
-            let devices = 1;
-            trace!("devices per user: {}", devices);
+            // # of matchkeys
+            // Hard code this number to 1 as, at the moment, we only have a solution for one match key.
+            let matchkeys = 1;
+            trace!("match keys per user: {}", matchkeys);
 
             let impressions = sample.impression_per_user(rng);
             trace!("impressions per user: {}", impressions);
@@ -171,7 +171,7 @@ pub fn generate_events<R: RngCore + CryptoRng, W: io::Write>(
 
             let events = gen_events(
                 &GenEventParams {
-                    devices,
+                    matchkeys,
                     impressions,
                     conversions,
                     epoch,
@@ -212,7 +212,7 @@ fn gen_events<R: RngCore + CryptoRng>(
 ) -> Vec<Event> {
     let mut events: Vec<Event> = Vec::new();
 
-    let matchkeys = gen_matchkeys(params.devices, rng);
+    let matchkeys = gen_matchkeys(params.matchkeys, rng);
     let mut ss_mks: Vec<SecretShare> = Vec::new();
 
     if secret_share {

--- a/src/bin/ipa_bench/sample.rs
+++ b/src/bin/ipa_bench/sample.rs
@@ -14,9 +14,6 @@ pub struct Sample<'a> {
     ad_impression_per_user_distr: WeightedIndex<f64>,
     ad_conversion_per_user_distr: WeightedIndex<f64>,
 
-    // Match key
-    devices_per_user_distr: WeightedIndex<f64>,
-
     // Time
     conversions_duration_distr: WeightedIndex<f64>,
     frequency_cap_distr: WeightedIndex<f64>,
@@ -43,11 +40,6 @@ impl<'a> Sample<'a> {
             .unwrap(),
             ad_conversion_per_user_distr: WeightedIndex::new(
                 config.conversion_per_user.iter().map(|i| i.weight),
-            )
-            .unwrap(),
-
-            devices_per_user_distr: WeightedIndex::new(
-                config.devices_per_user.iter().map(|i| i.weight),
             )
             .unwrap(),
 
@@ -80,10 +72,6 @@ impl<'a> Sample<'a> {
             .index
             .clone();
         rng.gen_range(r)
-    }
-
-    pub fn devices_per_user<R: RngCore + CryptoRng>(&self, rng: &mut R) -> u8 {
-        self.config.devices_per_user[self.devices_per_user_distr.sample(rng)].index
     }
 
     pub fn cvr_per_ad_account<R: RngCore + CryptoRng>(&self, rng: &mut R) -> f64 {

--- a/src/helpers/models.rs
+++ b/src/helpers/models.rs
@@ -8,6 +8,7 @@ use std::ops::Range;
 // Underlying types are temporalily assigned for PoC.
 pub type CipherText = Vec<u8>;
 type PlainText = String;
+type Number = u32;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
@@ -126,7 +127,7 @@ pub struct SourceEvent {
     pub event: Event,
 
     /// A key to group sets of the events.
-    pub breakdown_key: PlainText,
+    pub breakdown_key: Number,
 }
 
 #[cfg(feature = "debug")]
@@ -149,7 +150,7 @@ pub struct TriggerEvent {
 
     /// Zero knowledge proof that the trigger value lies within a specific range
     /// of values. The range is specified in [TriggerFanoutQuery].
-    pub zkp: PlainText,
+    pub zkp: Number,
 }
 
 #[cfg(feature = "debug")]

--- a/src/helpers/models.rs
+++ b/src/helpers/models.rs
@@ -147,10 +147,6 @@ pub struct TriggerEvent {
 
     /// Conversion value.
     pub value: SecretShare,
-
-    /// Zero knowledge proof that the trigger value lies within a specific range
-    /// of values. The range is specified in [TriggerFanoutQuery].
-    pub zkp: Number,
 }
 
 #[cfg(feature = "debug")]


### PR DESCRIPTION
## Overview

This diff changes source and trigger event structures in the following way:

1. Change "breakdown_key" and "zkp" fields' type from string to u32.
2. Duplicate fields that exist in trigger event to source event and vice versa. This ensures that two aribtrary data chunks are indistinguishable so that an observer cannot learn whether one is a source or trigger event.
3. Add a flag (boolean) to indicate whether the event type is source (false/0) or trigger(true/1).