### PR TITLE
Implementing random share generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ aes = "0.8"
 async-trait = "0.1.56"
 axum = { version = "0.5.7", optional = true, features = ["http2"] }
 axum-server = { version = "0.4.0", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
+bit-vec = "0.6.3"
 byteorder = "1"
 # rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, not 0.10
 digest = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cli;
 pub mod error;
 pub mod field;
 pub mod helpers;
+pub mod modulus_convert;
 pub mod net;
 pub mod prss;
 mod replicated_secret_sharing;

--- a/src/modulus_convert.rs
+++ b/src/modulus_convert.rs
@@ -1,0 +1,187 @@
+use crate::error::BoxError;
+use crate::field::Field;
+use crate::helpers::ring::Ring;
+use crate::prss::Participant;
+use crate::replicated_secret_sharing::ReplicatedSecretSharing;
+use crate::securemul::{ProtocolContext, SecureMul};
+use bit_vec::BitVec;
+
+pub enum HelperIdentity {
+    H1,
+    H2,
+    H3,
+}
+
+pub struct RandomShareGenerationHelper<'a> {
+    rng: &'a Participant,
+    identity: HelperIdentity,
+}
+
+impl<'a> RandomShareGenerationHelper<'a> {
+    #[must_use]
+    pub fn new(rng: &'a Participant, identity: HelperIdentity) -> Self {
+        Self { rng, identity }
+    }
+
+    #[must_use]
+    pub fn split_binary<T: Field>(
+        &self,
+        left: bool,
+        right: bool,
+    ) -> (
+        ReplicatedSecretSharing<T>,
+        ReplicatedSecretSharing<T>,
+        ReplicatedSecretSharing<T>,
+    ) {
+        let left = u128::from(left);
+        let right = u128::from(right);
+        match self.identity {
+            HelperIdentity::H1 => (
+                ReplicatedSecretSharing::new(T::from(left), T::ZERO),
+                ReplicatedSecretSharing::new(T::ZERO, T::from(right)),
+                ReplicatedSecretSharing::new(T::ZERO, T::ZERO),
+            ),
+            HelperIdentity::H2 => (
+                ReplicatedSecretSharing::new(T::ZERO, T::ZERO),
+                ReplicatedSecretSharing::new(T::from(left), T::ZERO),
+                ReplicatedSecretSharing::new(T::ZERO, T::from(right)),
+            ),
+            HelperIdentity::H3 => (
+                ReplicatedSecretSharing::new(T::ZERO, T::from(right)),
+                ReplicatedSecretSharing::new(T::ZERO, T::ZERO),
+                ReplicatedSecretSharing::new(T::from(left), T::ZERO),
+            ),
+        }
+    }
+
+    fn get_share_of_one<T: Field>(&self) -> ReplicatedSecretSharing<T> {
+        match self.identity {
+            HelperIdentity::H1 => ReplicatedSecretSharing::new(T::ONE, T::ZERO),
+            HelperIdentity::H2 => ReplicatedSecretSharing::new(T::ZERO, T::ZERO),
+            HelperIdentity::H3 => ReplicatedSecretSharing::new(T::ZERO, T::ONE),
+        }
+    }
+
+    #[must_use]
+    pub fn convert_shares_step_1<T: Field>(
+        input: u64,
+        r_shares: &[(bool, ReplicatedSecretSharing<T>)],
+    ) -> (Vec<ReplicatedSecretSharing<T>>, BitVec) {
+        let mut bit_vec = BitVec::from_bytes(&input.to_be_bytes());
+        for i in 0..64 {
+            let r_binary_share = r_shares[i].0;
+            bit_vec.set(i, bit_vec[i] ^ r_binary_share);
+        }
+        (r_shares.iter().map(|x| x.1).collect(), bit_vec)
+    }
+
+    #[must_use]
+    pub fn convert_shares_step_2<T: Field>(
+        &self,
+        input_xor_r: &BitVec,
+        r_shares: &[ReplicatedSecretSharing<T>],
+    ) -> Vec<ReplicatedSecretSharing<T>> {
+        let mut output = Vec::with_capacity(input_xor_r.len());
+        for i in 0..input_xor_r.len() {
+            let share = if input_xor_r[i] {
+                self.get_share_of_one() - r_shares[i]
+            } else {
+                r_shares[i]
+            };
+            output.push(share);
+        }
+        output
+    }
+
+    /// Runs the protocol to generate a pair of secret sharings of a random value "r" in [0, 1]
+    /// None of the three helpers will know what the value of "r" is
+    ///
+    /// ## Errors
+    /// Lots of things may go wrong here, as this method calls the "Secure Mult" implementation
+    /// If there is a timeout (or other error) it should be signalled in the response
+    pub async fn gen_r_pairs<T: Field, R: Ring>(
+        &self,
+        idx: u128,
+        ctx: &ProtocolContext<'_, R>,
+    ) -> Result<Vec<(bool, ReplicatedSecretSharing<T>)>, BoxError> {
+        let mut idx = idx;
+
+        let (left, right) = self.rng.generate_values(idx);
+        let mut output = Vec::with_capacity(128);
+        let left_bits = BitVec::from_bytes(&left.to_be_bytes());
+        let right_bits = BitVec::from_bytes(&right.to_be_bytes());
+        for i in 0..128 {
+            let left_bit = left_bits[i];
+            let right_bit = right_bits[i];
+            let r_shares = self.split_binary(left_bit, right_bit);
+
+            let r1_x_r2 = SecureMul::new(r_shares.0, r_shares.1, idx)
+                .execute(ctx)
+                .await?;
+
+            idx += 1;
+
+            let r1_xor_r2 = r_shares.0 + r_shares.1 - (r1_x_r2 * T::from(2));
+
+            let r1_xor_r2_x_r3 = SecureMul::new(r1_xor_r2, r_shares.2, idx)
+                .execute(ctx)
+                .await?;
+            idx += 1;
+
+            let r1_xor_r2_xor_r3 = r1_xor_r2 + r_shares.2 - (r1_xor_r2_x_r3 * T::from(2));
+
+            output.push((left_bit, r1_xor_r2_xor_r3));
+        }
+
+        Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::BoxError;
+    use crate::modulus_convert::{HelperIdentity, RandomShareGenerationHelper};
+
+    use crate::field::Fp31;
+    use crate::helpers;
+    use crate::helpers::ring::mock::TestHelper;
+
+    #[tokio::test]
+    async fn one_pair() -> Result<(), BoxError> {
+        let ring = helpers::ring::mock::make_three();
+        let participants = crate::prss::test::make_three();
+        let context = crate::securemul::tests::make_context(&ring, &participants);
+
+        let h1 = RandomShareGenerationHelper::new(&participants.0, HelperIdentity::H1);
+        let h2 = RandomShareGenerationHelper::new(&participants.1, HelperIdentity::H2);
+        let h3 = RandomShareGenerationHelper::new(&participants.2, HelperIdentity::H3);
+
+        let idx = 10;
+
+        let result_shares = tokio::try_join!(
+            h1.gen_r_pairs::<Fp31, TestHelper>(idx, &context[0]),
+            h2.gen_r_pairs::<Fp31, TestHelper>(idx, &context[1]),
+            h3.gen_r_pairs::<Fp31, TestHelper>(idx, &context[2]),
+        )?;
+
+        for i in 0..128 {
+            let h1_share = result_shares.0[i];
+            let h2_share = result_shares.1[i];
+            let h3_share = result_shares.2[i];
+
+            let expected_value: u128 = u128::from(h1_share.0 ^ h2_share.0 ^ h3_share.0);
+
+            crate::replicated_secret_sharing::tests::assert_valid_secret_sharing(
+                h1_share.1, h2_share.1, h3_share.1,
+            );
+            crate::replicated_secret_sharing::tests::assert_secret_shared_value(
+                h1_share.1,
+                h2_share.1,
+                h3_share.1,
+                expected_value,
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/src/replicated_secret_sharing.rs
+++ b/src/replicated_secret_sharing.rs
@@ -11,7 +11,7 @@ pub struct ReplicatedSecretSharing<T>(T, T);
 
 impl<T: Debug> Debug for ReplicatedSecretSharing<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({:?}, {:?}", self.0, self.1)
+        write!(f, "({:?}, {:?})", self.0, self.1)
     }
 }
 
@@ -59,7 +59,7 @@ impl<T: Field> Mul<T> for ReplicatedSecretSharing<T> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use crate::replicated_secret_sharing::ReplicatedSecretSharing;
 
     use crate::field::Fp31;
@@ -80,7 +80,7 @@ mod tests {
         )
     }
 
-    fn assert_valid_secret_sharing(
+    pub fn assert_valid_secret_sharing(
         res1: ReplicatedSecretSharing<Fp31>,
         res2: ReplicatedSecretSharing<Fp31>,
         res3: ReplicatedSecretSharing<Fp31>,
@@ -90,7 +90,7 @@ mod tests {
         assert_eq!(res3.1, res1.0);
     }
 
-    fn assert_secret_shared_value(
+    pub fn assert_secret_shared_value(
         a1: ReplicatedSecretSharing<Fp31>,
         a2: ReplicatedSecretSharing<Fp31>,
         a3: ReplicatedSecretSharing<Fp31>,

--- a/src/securemul.rs
+++ b/src/securemul.rs
@@ -42,6 +42,18 @@ pub enum Error {
 }
 
 impl<F: Field> SecureMul<F> {
+    pub fn new(
+        a_share: ReplicatedSecretSharing<F>,
+        b_share: ReplicatedSecretSharing<F>,
+        index: u128,
+    ) -> SecureMul<F> {
+        SecureMul {
+            index,
+            a_share,
+            b_share,
+        }
+    }
+
     /// Executes the secure multiplication on the MPC helper side. Each helper will proceed with
     /// their part, eventually producing 2/3 shares of the product and that is what this function
     /// returns.
@@ -151,7 +163,7 @@ pub mod stream {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
 
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -288,7 +300,12 @@ mod tests {
         Ok(validate_and_reconstruct(result_shares).into())
     }
 
-    fn make_context<'a>(
+    /// Creates a test context - only suitable for use in tests
+    ///
+    /// ## Panics
+    /// I'm not sure what can go wrong here.
+    #[must_use]
+    pub fn make_context<'a>(
         ring: &'a [TestHelper; 3],
         participants: &'a (Participant, Participant, Participant),
     ) -> [ProtocolContext<'a, TestHelper>; 3] {


### PR DESCRIPTION
In order to convert from an XOR secret sharing of the match key to a list of Replicated, additive secret shares, we need pairs of sharings of a random value "r", which is either 0 or 1, and none of the helpers should know the value of "r".

Now that @akoshelev has landed his secure multiplication struct - with async/await this code is MUCH more legible. Thank you so much!

This is NOT the optimized logic - but I figure I'll start with this simpler diff first.