### PR TITLE
Add support for running protocols concurrently

### DIFF
--- a/src/helpers/ring.rs
+++ b/src/helpers/ring.rs
@@ -284,9 +284,9 @@ pub mod mock {
         let tr = TestHelper::new(rx, tx.clone(), tx);
 
         {
-            let _r = tr.ring_channel(1_u128.into());
+            let _r = tr.ring_channel(1.into());
             {
-                let _r = tr.ring_channel(2_u128.into());
+                let _r = tr.ring_channel(2.into());
                 assert_eq!(tr.routing_table.lock().unwrap().active_routes.len(), 2);
             }
             assert_eq!(tr.routing_table.lock().unwrap().active_routes.len(), 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod field;
 pub mod helpers;
 pub mod net;
+pub mod protocols;
 pub mod prss;
 mod replicated_secret_sharing;
 pub mod report;

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -1,0 +1,10 @@
+/// unique protocol identifier, used to disambiguate messages of the same type sent towards
+/// the same set of helpers that perform multiple concurrent computations
+#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub struct ProtocolId(u128);
+
+impl From<u128> for ProtocolId {
+    fn from(v: u128) -> Self {
+        ProtocolId(v)
+    }
+}

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -1,7 +1,7 @@
 /// unique protocol identifier, used to disambiguate messages of the same type sent towards
 /// the same set of helpers that perform multiple concurrent computations
 #[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
-pub struct ProtocolId(u128);
+pub struct ProtocolId(u32);
 
 impl From<u128> for ProtocolId {
     fn from(v: u128) -> Self {

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -3,8 +3,8 @@
 #[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub struct ProtocolId(u32);
 
-impl From<u128> for ProtocolId {
-    fn from(v: u128) -> Self {
+impl From<u32> for ProtocolId {
+    fn from(v: u32) -> Self {
         ProtocolId(v)
     }
 }

--- a/src/securemul.rs
+++ b/src/securemul.rs
@@ -251,7 +251,7 @@ mod tests {
         let b = share(Fp31::from(3_u128), &mut rand);
 
         let mut multiplications = Vec::new();
-        for i in 1_u128..10 {
+        for i in 1..10_u128 {
             // there is something weird going on the compiler's side. I don't see why we need
             // to use async move as `i` is Copy + Clone, but compiler complains about it not living
             // long enough

--- a/src/securemul.rs
+++ b/src/securemul.rs
@@ -54,7 +54,10 @@ impl<F: Field> SecureMul<F> {
         self,
         ctx: &ProtocolContext<'_, R>,
     ) -> Result<ReplicatedSecretSharing<F>, BoxError> {
-        let mut helper_ring = ctx.helper_ring.ring_channel(ProtocolId::from(self.index));
+        #[allow(clippy::cast_possible_truncation)] // we will move away from using index soon (#68)
+        let mut helper_ring = ctx
+            .helper_ring
+            .ring_channel(ProtocolId::from(self.index as u32));
         // generate shared randomness.
         let (s0, s1) = ctx.prss.generate_fields(self.index);
 

--- a/src/securemul.rs
+++ b/src/securemul.rs
@@ -155,6 +155,7 @@ mod tests {
     use crate::field::{Field, Fp31};
     use crate::helpers;
     use crate::helpers::ring::mock::TestHelper;
+    use crate::prss::test::SingleSpace;
     use crate::prss::Participant;
     use crate::replicated_secret_sharing::ReplicatedSecretSharing;
     use crate::securemul::stream::secure_multiply;


### PR DESCRIPTION
## Overview

This PR partially addresses #62 and also adds support for running multiple protocols of the same type concurrently. For example, now it is possible to schedule as many multiplications as possible as long as all of them have unique protocol id. 

## Protocol id

Currently it is an opaque struct and secure multiplication uses seed index which may not be what we would want in the future, but it works for now


## Communication gateway

The fact that there can be many protocols running at the same time requires another layer of abstraction - starting protocols and dispatching messages to the receiving protocol correctly requires an orchestration struct that `CommunicationGateway` provides an abstraction for.  

`ProtocolContext` now carries a reference to the gateway instead of `Ring` and on API level makes it impossible to call `send` and `receive` without creating a channel first by calling `ring_channel`. See `SecureMul` for an example how this is now done. 

## Using channels instead of hashmap

It's been discussed in #62, but now per-protocol buffering is implemented using channels rather than storing messages inside a hashmap. That adds an additional requirement for messages to be sent in order, otherwise deserialization may fail. 
 