### PR TITLE
Field: add as_u128 method

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -77,6 +77,13 @@ pub trait Field:
 
         term
     }
+
+    /// Blanket implementation to represent the instance of this trait as 16 byte integer.
+    /// Uses the fact that such conversion already exists via `Self` -> `Self::Integer` -> `Into<u128>`
+    fn as_u128(&self) -> u128 {
+        let int: Self::Integer = (*self).into();
+        int.into()
+    }
 }
 
 // TODO(mt) - this code defining fields can be turned into a macro if we ever

--- a/src/securemul.rs
+++ b/src/securemul.rs
@@ -59,12 +59,7 @@ impl<F: Field> SecureMul<F> {
         // compute the value (d_i) we want to send to the right helper (i+1)
         let (a0, a1) = self.a_share.as_tuple();
         let (b0, b1) = self.b_share.as_tuple();
-        let right_d: F = a0 * b1 + a1 * b0 - s0;
-
-        // this ugliness is needed just to convert Field to u128. There are better ways to do it
-        // and there is a PR open to make it easier
-        let right_d: <F as Field>::Integer = right_d.into();
-        let right_d: u128 = right_d.into();
+        let right_d = (a0 * b1 + a1 * b0 - s0).as_u128();
 
         // notify helper on the right that we've computed our value
         ctx.helper_ring


### PR DESCRIPTION
It is convenient to have a common implementation without requiring all field implementations to define their own. Unfortunately I couldn't use (or I don't know how) `From<Field> for u128` because `Field` is a trait so I ended up defining a method on the trait itself.