### PR TITLE
Update commands in README.md

### DIFF
--- a/research-prototype/README.md
+++ b/research-prototype/README.md
@@ -105,17 +105,17 @@ COORDINATOR=<host IP or DNS>
 Run this command on the coordinator host
 
 ```bash
-../../MP-SPDZ/Scripts/../replicated-ring-party.x --player 0 ipae2e --hostname $COORDINATOR
+../../MP-SPDZ/replicated-ring-party.x --player 0 ipae2e --hostname $COORDINATOR
 ```
 
 Start two other MPC parties:
 
 host 1:
 ```bash
-../../MP-SPDZ/Scripts/../replicated-ring-party.x --player 1 ipae2e --hostname $COORDINATOR
+../../MP-SPDZ/replicated-ring-party.x --player 1 ipae2e --hostname $COORDINATOR
 ```
 
 host 2:
 ```bash
-../../MP-SPDZ/Scripts/../replicated-ring-party.x --player 1 ipae2e --hostname $COORDINATOR
+../../MP-SPDZ/replicated-ring-party.x --player 1 ipae2e --hostname $COORDINATOR
 ```


### PR DESCRIPTION
to call `replicated-ring-party.x` we don't need that many indirections, it was a copy-paste bug introduced by me.