### PR TITLE
Make Field serializable

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -4,6 +4,9 @@ use std::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
 // Trait for primitive integer types used to represent the underlying type for field values
 pub trait Int:
     Sized
@@ -38,7 +41,11 @@ pub trait Field:
     + Copy
     + PartialEq
     + Debug
+    + Send
     + Sized
+    + Serialize
+    + DeserializeOwned
+    + 'static
 {
     type Integer: Int;
 
@@ -90,6 +97,7 @@ pub trait Field:
 // need lots of fields with different primes.
 
 #[derive(Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct Fp31(<Self as Field>::Integer);
 
 impl From<Fp31> for u8 {


### PR DESCRIPTION
As we discussed in #55 it is a waste of space to use `u128` to send copies of `Fp31` between helpers. This change makes it a requirement for all fields to implement serialization. It also provides an out-of-the-box implementation for `Fp31` which is efficient enough (1 byte per instance) to be used in our test implementation.

Given that now `Field` elements may be sent across `await` points, there is a need for `Field` to be `Send + 'static`. 

Note that there are some issues with this implementation that need to be addressed

- The level of granularity for serializers (as well as buf writers) is byte (`u8`). Serde provides `serialize_u8` method and similar crates (`bytes`, "std::io::Cursor", etc) also work with bytes. That means if `Field` implementation needs 42 bits of information, we'll be paying 6 bit per instance price. That would result in extra 750 Mb sent for 1B events.

I think we may be able to handle that case with this API

```rust

trait Field {
   /// Number of bits needed to represent an element of this field in memory, ignoring padding and alignment.
   /// Note that it may not be the same as `Int::BITS`
   const BITS: u32;
}

// serialize
struct PeerBuffer {
  internal_buffer: RwLock<Vec<u8>>,
}

impl PeerBuffer {
    fn serialize<F: Field>(items: Vec<F>) -> usize {
     // elements of the vector `items` can still be serialized using serde, but only F::BITS LSB will be taken from each representation and stored inside the resulting slice. It is likely that we will have a single buffer per helper peer, so we can just allocate that buffer once and use RWLock to send the data stored inside it to the TCP socket
    }
}

// deserialize
struct FieldCursor<'a, F> {
   elements: &'a [u8],
}

impl FieldCursor<F: Field> {
   // Reads next F::BITS bits from elements array and attempts to interpret them as element of the field F.
   fn read_next(&mut self) -> de::Result<F>
}
```

- there is a need for Serde serializer that converts everything into raw bytes as efficiently as possible.