### PR TITLE
Use the MMO^pi function for PRSS

### DIFF
--- a/src/prss.rs
+++ b/src/prss.rs
@@ -179,13 +179,14 @@ pub struct Generator {
 
 impl Generator {
     /// Generate the value at the given index.
+    /// This uses the MMO^{\pi} function described in <https://eprint.iacr.org/2019/074>.
     #[must_use]
     pub fn generate(&self, index: u128) -> u128 {
         let mut buf = [0_u8; 16];
         LittleEndian::write_u128(&mut buf, index);
         self.cipher
             .encrypt_block(GenericArray::from_mut_slice(&mut buf));
-        LittleEndian::read_u128(&buf)
+        LittleEndian::read_u128(&buf) ^ index
     }
 }
 


### PR DESCRIPTION
I'm not entirely clear on the relative benefits of using this over the
fixed-key model of AES - particularly as we are reducing the `u128`
modulo $p << 2^{128}$ - but this seems like a relatively cheap way to
build the function.  This function provides correlation robustness,
whereas the fixed-key mode used previously does not.

Paper: https://eprint.iacr.org/2019/074
Function: $\mathsf{MMO}^{\pi}$