### PR TITLE
Fix new clippy warnings

### DIFF
--- a/src/helpers/ring.rs
+++ b/src/helpers/ring.rs
@@ -160,7 +160,7 @@ pub mod mock {
         async fn receive<T: Message>(&self, source: HelperAddr) -> Result<T, Error> {
             let buf = Arc::clone(&self.buf);
 
-            let res = tokio::spawn(async move {
+            tokio::spawn(async move {
                 loop {
                     {
                         let buf = &mut *buf.lock().unwrap();
@@ -180,8 +180,7 @@ pub mod mock {
             .map_err(|e| Error::ReceiveError {
                 source,
                 inner: Box::new(e) as _,
-            });
-            res
+            })
         }
     }
 

--- a/src/replicated_secret_sharing.rs
+++ b/src/replicated_secret_sharing.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::field::Field;
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ReplicatedSecretSharing<T>(T, T);
 
 impl<T: Debug> Debug for ReplicatedSecretSharing<T> {


### PR DESCRIPTION
Rust 1.63 brought some new clippy lints, fixing them to make main compile