### PR TITLE
[WIP] [Blocked] Secure Sort implementation 

### DIFF
--- a/src/find_sort_location.rs
+++ b/src/find_sort_location.rs
@@ -1,0 +1,142 @@
+#![allow(dead_code)]
+
+use futures::future::join_all;
+
+use crate::{
+    field::Field,
+    helpers::ring::Ring,
+    replicated_secret_sharing::ReplicatedSecretSharing,
+    securemul::{ProtocolContext, SecureMul},
+};
+
+pub struct SecureSort<'a, R, F> {
+    context: &'a ProtocolContext<'a, R>,
+    share_of_one: ReplicatedSecretSharing<F>,
+}
+
+impl<F: Field, R: Ring> SecureSort<'_, R, F> {
+    pub async fn execute(
+        self,
+        shares: &[ReplicatedSecretSharing<F>],
+    ) -> Vec<ReplicatedSecretSharing<F>> {
+        let gen_permutation_share = |mult_output: Vec<ReplicatedSecretSharing<F>>| {
+            let len = mult_output.len() / 2;
+
+            // Fold the result
+            let mut permutation_share = Vec::new();
+            (0..len).for_each(|j| {
+                permutation_share.push(mult_output[j] + mult_output[j + len]);
+            });
+            permutation_share
+        };
+        gen_permutation_share(self.secure_multiply(self.prepare_mult_inputs(shares)).await)
+    }
+
+    fn prepare_mult_inputs(
+        &self,
+        shares: &[ReplicatedSecretSharing<F>],
+    ) -> Vec<(ReplicatedSecretSharing<F>, ReplicatedSecretSharing<F>)> {
+        // Step1: Calculate x and 1 - x
+        let mut x_and_one_minus_x: Vec<ReplicatedSecretSharing<F>> =
+            shares.iter().map(|x| self.share_of_one - *x).collect();
+        x_and_one_minus_x.append(&mut shares.to_owned());
+
+        // Step2: Calculate cumulative sum
+        let length = x_and_one_minus_x.len();
+        let mut cumulative_sum = Vec::with_capacity(length);
+        cumulative_sum.push(x_and_one_minus_x[0]);
+        for i in 1..length {
+            cumulative_sum.push(cumulative_sum[i - 1] + x_and_one_minus_x[i]);
+        }
+
+        // Step3: Consolidate step 1 and step 2 output
+        x_and_one_minus_x
+            .iter()
+            .zip(cumulative_sum.iter())
+            .map(|(x_and_one_minus, cumulative_sum)| (*x_and_one_minus, *cumulative_sum))
+            .collect()
+    }
+
+    async fn secure_multiply(
+        &self,
+        mult_inputs: Vec<(ReplicatedSecretSharing<F>, ReplicatedSecretSharing<F>)>,
+    ) -> Vec<ReplicatedSecretSharing<F>> {
+        // Spawn all multiplication, wait for them to finish in parallel and then collect the results
+        let async_multiply = mult_inputs.iter().enumerate().map(|(index, input)| {
+            let output = SecureMul {
+                a_share: input.0,
+                b_share: input.1,
+                index: index as u128,
+            };
+            output.execute(self.context)
+        });
+        join_all(
+            async_multiply
+                .into_iter()
+                .map(|handle| async { handle.await.unwrap() }),
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        field::Fp31,
+        helpers::{self, ring::mock::TestHelper},
+        replicated_secret_sharing::ReplicatedSecretSharing,
+    };
+
+    use super::SecureSort;
+
+    #[tokio::test]
+    async fn find_sorted_position() {
+        let ring = helpers::ring::mock::make_three();
+        let participants = crate::prss::test::make_three();
+        let context = crate::securemul::tests::make_context(&ring, &participants);
+        let mut secure_sort_output = Vec::new();
+
+        let input = [
+            (1, 0, 0),
+            (0, 0, 0),
+            (0, 1, 0),
+            (0, 0, 0),
+            (0, 0, 0),
+            (0, 0, 0),
+        ]
+        .to_vec();
+        let mut shares = [Vec::new(), Vec::new(), Vec::new()];
+
+        for iter in input {
+            let replicated_ss =
+                crate::replicated_secret_sharing::tests::secret_share(iter.0, iter.1, iter.2);
+            shares[0].push(replicated_ss.0);
+            shares[1].push(replicated_ss.1);
+            shares[2].push(replicated_ss.2);
+        }
+
+        for i in 0..3 {
+            let secure_sort = SecureSort::<TestHelper, Fp31> {
+                context: &context[i],
+                share_of_one: match i {
+                    0 => ReplicatedSecretSharing::new(Fp31::from(1_u8), Fp31::from(0_u8)),
+                    1 => ReplicatedSecretSharing::new(Fp31::from(0_u8), Fp31::from(0_u8)),
+                    _ => ReplicatedSecretSharing::new(Fp31::from(0_u8), Fp31::from(1_u8)),
+                },
+            };
+            secure_sort_output.push(secure_sort.execute(&shares[i]).await);
+        }
+
+        let expected_sort_output = [5_u128, 1, 6, 2, 3, 4].as_ref();
+
+        (0..secure_sort_output[0].len()).for_each(|i| {
+            assert_eq!(
+                secure_sort_output[0][i] + secure_sort_output[1][i] + secure_sort_output[2][i],
+                ReplicatedSecretSharing::new(
+                    Fp31::from(expected_sort_output[i]),
+                    Fp31::from(expected_sort_output[i])
+                )
+            );
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod chunkscan;
 pub mod cli;
 pub mod error;
 pub mod field;
+mod find_sort_location;
 pub mod helpers;
 pub mod net;
 pub mod prss;

--- a/src/replicated_secret_sharing.rs
+++ b/src/replicated_secret_sharing.rs
@@ -59,12 +59,12 @@ impl<T: Field> Mul<T> for ReplicatedSecretSharing<T> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use crate::replicated_secret_sharing::ReplicatedSecretSharing;
 
     use crate::field::Fp31;
 
-    fn secret_share(
+    pub(crate) fn secret_share(
         a: u8,
         b: u8,
         c: u8,

--- a/src/securemul.rs
+++ b/src/securemul.rs
@@ -12,9 +12,9 @@ use thiserror::Error;
 /// K. Chida, K. Hamada, D. Ikarashi, R. Kikuchi, and B. Pinkas. High-throughput secure AES computation. In WAHC@CCS 2018, pp. 13–24, 2018
 #[derive(Debug)]
 pub struct SecureMul<F> {
-    index: u128,
-    a_share: ReplicatedSecretSharing<F>,
-    b_share: ReplicatedSecretSharing<F>,
+    pub index: u128,
+    pub a_share: ReplicatedSecretSharing<F>,
+    pub b_share: ReplicatedSecretSharing<F>,
 }
 
 /// A message sent by each helper when they've multiplied their own shares
@@ -146,7 +146,7 @@ pub mod stream {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
 
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -283,7 +283,7 @@ mod tests {
         Ok(validate_and_reconstruct(result_shares).into())
     }
 
-    fn make_context<'a>(
+    pub(crate) fn make_context<'a>(
         ring: &'a [TestHelper; 3],
         participants: &'a (Participant, Participant, Participant),
     ) -> [ProtocolContext<'a, TestHelper>; 3] {


### PR DESCRIPTION
[WIP] 
Implementing Radix Sort using the approach described in https://eprint.iacr.org/2019/695.pdf
Before calling mpc_sort function, caller is expected to transform the bits into modulus conversion and send secret shared inputs to the function.
The entire flow of the implementation is represented in this diagram.

![image](https://user-images.githubusercontent.com/6997829/184381745-ad30afea-2b7a-4874-83ea-73855bafcc31.png)

This diff implements finding order of each input in the sorted list. 

For now this diff is blocked on executing multiple secure multiplication in parallel. I am parking this PR for using later once those changes are made. The test in this PR fails due to parallelization not handled