### PR TITLE
Add Helper Identity enum

### DIFF
--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -17,7 +17,7 @@ pub use event::{
 use crate::error::{Error, Res};
 use crate::threshold::EncryptionKey as ThresholdEncryptionKey;
 #[cfg(feature = "enable-serde")]
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Error as FmtError, Formatter};
 #[cfg(feature = "enable-serde")]
 use std::fs;
@@ -26,6 +26,15 @@ use std::ops::Index;
 #[cfg(feature = "enable-serde")]
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+
+/// Represents a unique identity of each helper running MPC computation.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub enum Identity {
+    H1,
+    H2,
+    H3,
+}
 
 #[derive(Debug)]
 pub struct HelperRoleUnknown(String);

--- a/src/helpers/ring.rs
+++ b/src/helpers/ring.rs
@@ -8,6 +8,7 @@
 //! enables MPC helper service to do.
 //!
 use crate::helpers::error::Error;
+use crate::helpers::Identity;
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -34,12 +35,16 @@ pub trait Ring {
     /// to wait until `dest` acknowledges message or simply put it to a outgoing queue
     async fn send<T: Message>(&self, dest: HelperAddr, msg: T) -> Result<(), Error>;
     async fn receive<T: Message>(&self, source: HelperAddr) -> Result<T, Error>;
+
+    /// Returns the unique identity of this helper.
+    fn identity(&self) -> Identity;
 }
 
 #[cfg(test)]
 pub mod mock {
     use crate::helpers::error::Error;
     use crate::helpers::ring::{HelperAddr, Message, Ring};
+    use crate::helpers::Identity;
     use async_trait::async_trait;
     use std::any::TypeId;
     use std::collections::hash_map::Entry;
@@ -68,6 +73,8 @@ pub mod mock {
     /// receive it.
     #[derive(Debug)]
     pub struct TestHelper {
+        identity: Identity,
+
         // A handle to send message to this helper
         input_queue: Sender<MessageEnvelope>,
 
@@ -89,7 +96,7 @@ pub mod mock {
         /// Panics if Mutex used internally for synchronization is poisoned or if there are more
         /// than one message with the same type id and destination address arriving via `send` call.
         #[must_use]
-        pub fn new(buf_capacity: usize) -> Self {
+        pub fn new(id: Identity, buf_capacity: usize) -> Self {
             let (tx, mut rx) = channel::<MessageEnvelope>(buf_capacity);
             let buf = Arc::new(Mutex::new(HashMap::new()));
 
@@ -112,6 +119,7 @@ pub mod mock {
             });
 
             Self {
+                identity: id,
                 input_queue: tx,
                 left: None,
                 right: None,
@@ -182,6 +190,10 @@ pub mod mock {
                 inner: Box::new(e) as _,
             })
         }
+
+        fn identity(&self) -> Identity {
+            self.identity
+        }
     }
 
     /// Creates 3 test helper instances and orchestrates them into a ring.
@@ -189,9 +201,9 @@ pub mod mock {
     pub fn make_three() -> [TestHelper; 3] {
         let buf_capacity = 10;
         let mut helpers = [
-            TestHelper::new(buf_capacity),
-            TestHelper::new(buf_capacity),
-            TestHelper::new(buf_capacity),
+            TestHelper::new(Identity::H1, buf_capacity),
+            TestHelper::new(Identity::H2, buf_capacity),
+            TestHelper::new(Identity::H3, buf_capacity),
         ];
 
         helpers[0].set_left(helpers[2].input_queue.clone());


### PR DESCRIPTION
There seem to be more and more protocols we need to implement that require helpers to know their exact position inside the MPC ring. For instance, modulus conversion needs to construct binary secret shares differently depending on which helper performs this operation (#63).

Secure sort (#66) seem to need that as well as it requires helpers to agree on constructing a secret share of `1`.

This change adds necessary plumbing to make helper identity available for protocol writers - `ctx.helper_ring.identity()` should return the exact helper location