### PR TITLE
Update source/trigger events structure for synthetic data generation

### DIFF
--- a/src/bin/ipa_bench/cmd.rs
+++ b/src/bin/ipa_bench/cmd.rs
@@ -90,9 +90,6 @@ pub enum Command {
         )]
         epoch: u8,
 
-        #[structopt(long, help = "Output secret shared values")]
-        secret_share: bool,
-
         #[structopt(
             short,
             long,
@@ -112,17 +109,9 @@ impl Command {
                 scale_factor,
                 random_seed,
                 epoch,
-                secret_share,
                 config_file,
             } => {
-                Command::gen_events(
-                    common,
-                    *scale_factor,
-                    random_seed,
-                    *epoch,
-                    *secret_share,
-                    config_file,
-                );
+                Command::gen_events(common, *scale_factor, random_seed, *epoch, config_file);
             }
         }
     }
@@ -132,7 +121,6 @@ impl Command {
         scale_factor: u32,
         random_seed: &Option<u64>,
         epoch: u8,
-        secret_share: bool,
         config_file: &Path,
     ) {
         let mut input = Command::get_input(&Some(config_file.to_path_buf())).unwrap_or_else(|e| {
@@ -158,15 +146,12 @@ impl Command {
         let sample = Sample::new(&config);
 
         let mut rng = random_seed.map_or(StdRng::from_entropy(), StdRng::seed_from_u64);
-        let mut ss_rng = random_seed.map_or(StdRng::from_entropy(), StdRng::seed_from_u64);
 
         let (s_count, t_count) = generate_events(
             &sample,
             DEFAULT_EVENT_GEN_COUNT * scale_factor,
             epoch,
-            secret_share,
             &mut rng,
-            &mut ss_rng,
             &mut out,
         );
 


### PR DESCRIPTION
## Overview
This diff updates source and trigger structs used for synthetic data generation. Synthetic data will be used to either create an attribution report benchmark (executed in clear), or transform the data into encrypted and secret shared format to be fed to IPA to generate reproducible test results.
Data structure is (almost) the same as the one specified in the [end-to-end doc](https://github.com/patcg-individual-drafts/ipa/blob/main/IPA-End-to-End.md#gathering-events). Just not encrypted nor secret shared.

```
struct {
    int match_key_share;
    int attribution_constraint_id_share;
    int timestamp_share;
    int is_trigger_report_share;
    int breakdown_key_share;
    int trigger_value_share;
} generic_report_share
```

## What have changed?
* Merged source and trigger events into `GenericReport`
* Report only contains 1 match key instead of multiple
* Added `attribution_constraint_id`
* Removed --secret-share option. If the test data needs to be fed into MPC, we can create another module which encrypts and secret shares the data (not part of this diff).

Since this tool's purpose is to generate human-readable test data, resulting output contains fields in clear and not secret shared.