### PR TITLE
[Semi honest sort] Computing bit permutations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,9 @@ tokio = { version = "1.19.2", optional = true, features = ["rt", "rt-multi-threa
 tokio-stream = { version = "0.1.9", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.3.4", optional = true, features = ["trace"] }
-tracing = "0.1.35"
-tracing-subscriber = { version = "0.3.14", optional = true }
+# disable debug traces and below for release builds and keep everything for debug build
+tracing = { version = "0.1.35", features = ["max_level_trace", "release_max_level_info"] }
+tracing-subscriber = { version = "0.3.14", optional = true, features = ["env-filter"] }
 x25519-dalek = "2.0.0-pre.1"
 
 [dev-dependencies]

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "http" => BindTarget::Http(addr),
         #[cfg(feature = "self-signed-certs")]
         "https" => {
-            let config = raw_ipa::net::tls_config_from_self_signed_cert().await?;
+            let config = raw_ipa::cli::net::tls_config_from_self_signed_cert().await?;
             BindTarget::Https(addr, config)
         }
         _ => {

--- a/src/helpers/mesh.rs
+++ b/src/helpers/mesh.rs
@@ -6,9 +6,11 @@
 //! corresponding helper without needing to know the exact location - this is what this module
 //! enables MPC helper service to do.
 //!
+use crate::field::Field;
 use crate::helpers::error::Error;
 use crate::helpers::Identity;
 use crate::protocol::{RecordId, Step};
+use crate::secret_sharing::Replicated;
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -38,6 +40,15 @@ pub trait Mesh {
 
     /// Returns the unique identity of this helper.
     fn identity(&self) -> Identity;
+
+    /// Returns share of value one for this helper.
+    fn share_of_one<F: Field>(&self) -> Replicated<F> {
+        match self.identity() {
+            Identity::H1 => Replicated::new(F::ONE, F::ZERO),
+            Identity::H2 => Replicated::new(F::ZERO, F::ZERO),
+            Identity::H3 => Replicated::new(F::ZERO, F::ONE),
+        }
+    }
 }
 
 /// This is the entry point for protocols to request communication when they require it.

--- a/src/helpers/mock.rs
+++ b/src/helpers/mock.rs
@@ -9,9 +9,12 @@ use futures_util::stream::SelectAll;
 use futures_util::StreamExt;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex};
+
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
+use tracing::Instrument;
 
 /// Gateway is just the proxy for `Controller` interface to provide stable API and hide
 /// `Controller`'s dependencies
@@ -32,7 +35,6 @@ pub struct TestMesh<S> {
 }
 
 /// Represents control messages sent between helpers to handle infrastructure requests.
-#[derive(Debug)]
 enum ControlMessage<S> {
     /// Connection for step S is requested by the peer
     ConnectionRequest(Identity, S, mpsc::Receiver<MessageEnvelope>),
@@ -66,7 +68,6 @@ enum BufItem {
     Received(Box<[u8]>),
 }
 
-#[derive(Debug)]
 struct ReceiveRequest<S> {
     from: Identity,
     step: S,
@@ -166,6 +167,7 @@ impl<S: Step> Gateway<TestMesh<S>, S> for TestHelperGateway<S> {
 
 #[async_trait]
 impl<S: Step> Mesh for TestMesh<S> {
+    #[tracing::instrument(skip(self), level = "trace")]
     async fn send<T: Message>(
         &mut self,
         target: Identity,
@@ -188,13 +190,11 @@ impl<S: Step> Mesh for TestMesh<S> {
         Ok(())
     }
 
-    async fn receive<T: Message>(
-        &mut self,
-        source: Identity,
-        record: RecordId,
-    ) -> Result<T, Error> {
-        let payload = self.controller.receive(source, self.step, record).await;
+    #[tracing::instrument(skip(self), fields(identity=?self.controller.identity, step=?self.step), level="trace")]
+    async fn receive<T: Message>(&mut self, from: Identity, record: RecordId) -> Result<T, Error> {
+        let payload = self.controller.receive(from, self.step, record).await;
         let obj: T = serde_json::from_slice(&payload).unwrap();
+        tracing::trace!("message received: {obj:?}");
 
         Ok(obj)
     }
@@ -229,12 +229,13 @@ impl<S: Step> Controller<S> {
             peers: control_tx,
         };
 
-        Controller::start(control_rx, receive_rx);
+        Controller::start(identity, control_rx, receive_rx);
 
         controller
     }
 
     fn start(
+        identity: Identity,
         mut control_rx: mpsc::Receiver<ControlMessage<S>>,
         mut receive_rx: mpsc::Receiver<ReceiveRequest<S>>,
     ) {
@@ -249,6 +250,7 @@ impl<S: Step> Controller<S> {
                 // * Handle the request to receive a message from another helper
                 tokio::select! {
                     Some(control_message) = control_rx.recv() => {
+                        tracing::debug!("new {control_message:?}");
                         match control_message {
                             ControlMessage::ConnectionRequest(peer, step, peer_connection) => {
                                 channels.push(prepend((peer, step), ReceiverStream::new(peer_connection)));
@@ -256,23 +258,27 @@ impl<S: Step> Controller<S> {
                         }
                     }
                     Some(receive_request) = receive_rx.recv() => {
+                        tracing::trace!("new {:?}", receive_request);
                         buf.entry(receive_request.channel_id())
                            .or_default()
                            .receive_request(receive_request.record_id, receive_request.sender);
                     }
                     Some(((from_peer, step), message_envelope)) = channels.next() => {
+                        tracing::trace!("new MessageArrival(from={from_peer:?}, step={step:?}, record={:?}, size={}B)", message_envelope.record_id, message_envelope.payload.len());
                         buf.entry((from_peer, step))
                            .or_default()
                            .receive_message(message_envelope);
                     }
                     else => {
+                        tracing::debug!("All channels are closed and event loop is terminated");
                         break;
                     }
                 }
             }
-        });
+        }.instrument(tracing::info_span!("helper_event_loop", identity=?identity)));
     }
 
+    #[tracing::instrument(skip(self), level = "trace")]
     async fn get_connection(&self, peer: Identity, step: S) -> mpsc::Sender<MessageEnvelope> {
         assert_ne!(self.identity, peer);
 
@@ -288,6 +294,7 @@ impl<S: Step> Controller<S> {
         };
 
         if let Some(rx) = rx {
+            tracing::trace!("Requesting connection");
             self.peers
                 .get(&peer)
                 .expect("peer with id {peer:?} should exist")
@@ -335,4 +342,24 @@ fn make_controllers<S: Step>() -> [Controller<S>; 3] {
 
 pub fn prepend<T: Copy + Clone, S: Stream>(id: T, stream: S) -> impl Stream<Item = (T, S::Item)> {
     stream.map(move |item| (id, item))
+}
+
+impl<S: Step> Debug for ControlMessage<S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ControlMessage::ConnectionRequest(from, step, _) => {
+                write!(f, "ConnectionRequest(from={:?}, step={:?})", from, step)
+            }
+        }
+    }
+}
+
+impl<S: Step> Debug for ReceiveRequest<S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ReceiveRequest(from={:?}, step={:?}, record={:?})",
+            self.from, self.step, self.record_id
+        )
+    }
 }

--- a/src/helpers/mock.rs
+++ b/src/helpers/mock.rs
@@ -1,14 +1,16 @@
-///! Provides an implementation of `Gateway` and `Mesh` suitable for unit tests.
+/// Provides an implementation of `Gateway` and `Mesh` suitable for unit tests.
+use std::collections::HashMap;
+
 use crate::helpers::error::Error;
 use crate::helpers::mesh::{Gateway, Mesh, Message};
 use crate::helpers::Identity;
 use crate::protocol::{RecordId, Step};
+
 use async_trait::async_trait;
 use futures::Stream;
 use futures_util::stream::SelectAll;
 use futures_util::StreamExt;
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::clone_on_ref_ptr)]
 
-#[cfg(feature = "cli")]
 pub mod chunkscan;
 pub mod cli;
 pub mod error;

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -1,6 +1,6 @@
 use crate::helpers::prss::{Participant, SpaceIndex};
 
-use super::{RecordId, Step, securemul::SecureMul};
+use super::{securemul::SecureMul, RecordId, Step};
 
 /// Context used by each helper to perform computation. Currently they need access to shared
 /// randomness generator (see `Participant`) and communication trait to send messages to each other.

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -1,6 +1,6 @@
 use crate::helpers::prss::{Participant, SpaceIndex};
 
-use super::{securemul::SecureMul, RecordId, Step};
+use super::{RecordId, Step, securemul::SecureMul};
 
 /// Context used by each helper to perform computation. Currently they need access to shared
 /// randomness generator (see `Participant`) and communication trait to send messages to each other.
@@ -9,7 +9,7 @@ use super::{securemul::SecureMul, RecordId, Step};
 #[derive(Debug)]
 pub struct ProtocolContext<'a, G, S: SpaceIndex> {
     participant: &'a Participant<S>,
-    gateway: &'a G,
+    pub gateway: &'a G,
 }
 
 impl<'a, G, S: Step + SpaceIndex> ProtocolContext<'a, G, S> {

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -24,6 +24,7 @@ impl<'a, G, S: Step + SpaceIndex> ProtocolContext<'a, G, S> {
     /// to allow backpressure if infrastructure layer cannot keep up with protocols demand.
     /// In this case, function returns only when multiplication for this record can actually
     /// be processed.
+    #[allow(clippy::unused_async)] // eventually there will be await b/c of backpressure implementation
     pub async fn multiply(&'a self, record_id: RecordId, step: S) -> SecureMul<'a, G, S> {
         SecureMul::new(&self.participant[step], self.gateway, step, record_id)
     }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,7 +1,7 @@
 pub mod context;
 mod securemul;
 
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 
 /// Defines a unique step of the IPA protocol. Step is a transformation that takes an input
@@ -24,19 +24,40 @@ use std::hash::Hash;
 pub trait Step: Copy + Clone + Debug + Eq + Hash + Send + 'static {}
 
 /// Set of steps that define the IPA protocol.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum IPAProtocolStep {
     /// Convert from XOR shares to Replicated shares
-    ConvertShares(ShareConversionStep),
+    ConvertShares,
     /// Sort shares by the match key
     Sort(SortStep),
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum ShareConversionStep {}
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum SortStep {
+    GenBitPermutations,
+}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum SortStep {}
+impl Debug for IPAProtocolStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IPA/")?;
+        match self {
+            IPAProtocolStep::ConvertShares => {
+                write!(f, "ConvertShares")
+            }
+            IPAProtocolStep::Sort(sort_step) => {
+                write!(f, "Sort/{:?}", sort_step)
+            }
+        }
+    }
+}
+
+impl Debug for SortStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SortStep::GenBitPermutations => write!(f, "GenBitPermutations"),
+        }
+    }
+}
 
 impl Step for IPAProtocolStep {}
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,8 +1,11 @@
 pub mod context;
 mod securemul;
+mod sort;
 
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
+
+use crate::helpers::prss::SpaceIndex;
 
 /// Defines a unique step of the IPA protocol. Step is a transformation that takes an input
 /// in form of a share or set of shares and produces the secret-shared output.
@@ -34,7 +37,7 @@ pub enum IPAProtocolStep {
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SortStep {
-    GenBitPermutations,
+    BitPermutations,
 }
 
 impl Debug for IPAProtocolStep {
@@ -54,12 +57,33 @@ impl Debug for IPAProtocolStep {
 impl Debug for SortStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            SortStep::GenBitPermutations => write!(f, "GenBitPermutations"),
+            SortStep::BitPermutations => write!(f, "BitPermutations"),
         }
     }
 }
 
 impl Step for IPAProtocolStep {}
+
+impl SpaceIndex for IPAProtocolStep {
+    const MAX: usize = 2;
+
+    fn as_usize(&self) -> usize {
+        match self {
+            IPAProtocolStep::ConvertShares => 0,
+            IPAProtocolStep::Sort(_) => 1,
+        }
+    }
+}
+
+impl Step for SortStep {}
+
+impl SpaceIndex for SortStep {
+    const MAX: usize = 1;
+
+    fn as_usize(&self) -> usize {
+        0
+    }
+}
 
 /// Unique identifier of the MPC query requested by report collectors
 /// TODO: Generating this unique id may be tricky as it may involve communication between helpers and

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -1,4 +1,4 @@
-use crate::error::BoxError;
+use crate::error::BoxError;&
 use crate::field::Field;
 use crate::helpers::mesh::{Gateway, Mesh};
 use crate::helpers::{prss::PrssSpace, Direction};
@@ -219,7 +219,7 @@ pub mod stream {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     use crate::field::{Field, Fp31};
@@ -233,16 +233,16 @@ mod tests {
 
     use crate::error::BoxError;
 
-    use crate::helpers::mock::TestHelperGateway;
     use crate::protocol::{QueryId, RecordId};
     use crate::test_fixture::{
-        logging, make_contexts, make_world, share, validate_and_reconstruct, TestStep,
+        logging, make_contexts, make_world, share, validate_and_reconstruct, TestStep, TestWorld,
     };
 
     #[tokio::test]
     async fn basic() -> Result<(), BoxError> {
         logging::setup();
-        let world = make_world(QueryId);
+
+        let world: TestWorld<TestStep> = make_world(QueryId);
         let context = make_contexts(&world);
         let mut rand = StepRng::new(1, 1);
 

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -1,4 +1,4 @@
-use crate::error::BoxError;&
+use crate::error::BoxError;
 use crate::field::Field;
 use crate::helpers::mesh::{Gateway, Mesh};
 use crate::helpers::{prss::PrssSpace, Direction};
@@ -223,6 +223,7 @@ pub mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     use crate::field::{Field, Fp31};
+    use crate::helpers::mock::TestHelperGateway;
     use crate::protocol::context::ProtocolContext;
     use rand::rngs::mock::StepRng;
 

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -158,7 +158,7 @@ pub mod stream {
         use crate::protocol::securemul::stream::secure_multiply;
         use crate::protocol::QueryId;
         use crate::secret_sharing::Replicated;
-        use crate::test_fixture::{make_world, share, validate_and_reconstruct};
+        use crate::test_fixture::{logging, make_world, share, validate_and_reconstruct};
         use futures::StreamExt;
         use futures_util::future::join_all;
         use futures_util::stream;
@@ -168,6 +168,9 @@ pub mod stream {
         /// of a `Stream`.
         #[tokio::test]
         async fn supports_stream_of_secret_shares() {
+            // beforeEach is not a thing in Rust yet: https://github.com/rust-lang/rfcs/issues/1664
+            logging::setup();
+
             // we compute a*b*c in this test. 4*3*2 = 24
             let mut rand = StepRng::new(1, 1);
             let a = share(Fp31::from(4_u128), &mut rand);
@@ -216,7 +219,7 @@ pub mod stream {
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     use crate::field::{Field, Fp31};
@@ -233,11 +236,12 @@ pub mod tests {
     use crate::helpers::mock::TestHelperGateway;
     use crate::protocol::{QueryId, RecordId};
     use crate::test_fixture::{
-        make_contexts, make_world, share, validate_and_reconstruct, TestStep,
+        logging, make_contexts, make_world, share, validate_and_reconstruct, TestStep,
     };
 
     #[tokio::test]
     async fn basic() -> Result<(), BoxError> {
+        logging::setup();
         let world = make_world(QueryId);
         let context = make_contexts(&world);
         let mut rand = StepRng::new(1, 1);
@@ -260,6 +264,8 @@ pub mod tests {
     #[tokio::test]
     #[allow(clippy::cast_possible_truncation)]
     pub async fn concurrent_mul() {
+        logging::setup();
+
         let world = make_world(QueryId);
         let context = make_contexts(&world);
         let mut rand = StepRng::new(1, 1);

--- a/src/protocol/sort/bit_permutations.rs
+++ b/src/protocol/sort/bit_permutations.rs
@@ -1,0 +1,159 @@
+use crate::{
+    error::BoxError,
+    field::Field,
+    helpers::mesh::{Gateway, Mesh},
+    protocol::{context::ProtocolContext, IPAProtocolStep, RecordId, SortStep},
+    secret_sharing::Replicated,
+};
+
+use futures::future::try_join_all;
+
+#[derive(Debug)]
+pub struct BitPermutations<'a, F> {
+    input: &'a [Replicated<F>],
+}
+
+impl<'a, F: Field> BitPermutations<'a, F> {
+    /// Create an object to generate bit permutations for a given bit column of query. This is GENBITPERM(Algorithm 3) from the paper
+    #[allow(dead_code)]
+    pub fn new(input: &'a [Replicated<F>]) -> BitPermutations<'a, F> {
+        Self { input }
+    }
+
+    /// In this step, multiplication inputs are generated locally at each helper from input share, x in following steps
+    /// 1. calculate 1 - x, x and concatenate them
+    /// 2. calculate cumulative sum at each vector row
+    /// 3. return back tuple of step 1 and step 2 output
+    fn prepare_mult_inputs<M: Mesh, G: Gateway<M, IPAProtocolStep>>(
+        &self,
+        ctx: &ProtocolContext<'_, G, IPAProtocolStep>,
+    ) -> Vec<(Replicated<F>, Replicated<F>)>
+    where
+        F: Field,
+    {
+        let channel = ctx
+            .gateway
+            .get_channel(IPAProtocolStep::Sort(SortStep::BitPermutations));
+
+        self.input
+            .iter()
+            .map(|x| channel.share_of_one() - *x)
+            .chain(self.input.iter().copied())
+            .scan(Replicated::<F>::new(F::ZERO, F::ZERO), |sum, n| {
+                *sum = *sum + n;
+                Some((n, *sum))
+            })
+            .collect()
+    }
+
+    /// multiplies the input vector pairs across helpers and returns result
+    /// For this, it spawns all multiplication, wait for them to finish in parallel and then collect the results
+
+    #[allow(clippy::cast_possible_truncation)]
+    async fn secure_multiply<M: Mesh, G: Gateway<M, IPAProtocolStep>>(
+        &self,
+        ctx: &ProtocolContext<'_, G, IPAProtocolStep>,
+        mult_inputs: Vec<(Replicated<F>, Replicated<F>)>,
+    ) -> Result<Vec<Replicated<F>>, BoxError>
+    where
+        F: Field,
+    {
+        let async_multiply = mult_inputs
+            .iter()
+            .enumerate()
+            .map(|(index, input)| async move {
+                ctx.multiply(
+                    RecordId::from(index as u32),
+                    IPAProtocolStep::Sort(SortStep::BitPermutations),
+                )
+                .await
+                .execute(input.0, input.1)
+                .await
+            });
+
+        try_join_all(async_multiply).await
+    }
+
+    /// Executes sorting of a bit column on mpc helpers. Each helper receives their input shares and do following steps
+    /// 1. local computation by `prepare_mult_inputs` which outputs 2 vectors [x,y]
+    /// 2. multiply each row of previous output individually (i.e. x*y) across mpc helpers.
+    /// 3. add ith column by i+len to obtain helper's share of sorted location, where len is same as input shares length
+    #[allow(dead_code)]
+    pub async fn execute<M: Mesh, G: Gateway<M, IPAProtocolStep>>(
+        self,
+        ctx: &ProtocolContext<'_, G, IPAProtocolStep>,
+    ) -> Result<Vec<Replicated<F>>, BoxError>
+    where
+        F: Field,
+    {
+        let mult_input = self.prepare_mult_inputs(ctx);
+        assert_eq!(mult_input.len(), self.input.len() * 2);
+
+        let mut mult_output = self.secure_multiply(ctx, mult_input).await?;
+        assert_eq!(mult_output.len(), self.input.len() * 2);
+        // Generate permutation location
+        let len = mult_output.len() / 2;
+        for i in 0..len {
+            mult_output[i] = mult_output[i] + mult_output[i + len];
+        }
+        mult_output.truncate(len);
+
+        Ok(mult_output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::rngs::mock::StepRng;
+    use tokio::try_join;
+
+    use crate::{
+        field::Fp31,
+        protocol::{securemul, sort::bit_permutations::BitPermutations, IPAProtocolStep, QueryId}, test_fixture::{make_world,validate_and_reconstruct, TestWorld, make_contexts, share},
+    };
+
+    #[tokio::test]
+    pub async fn bit_permutations() {
+        let world: TestWorld<IPAProtocolStep> = make_world(QueryId);
+        let context = make_contexts(&world);
+        let mut rand = StepRng::new(100, 1);
+
+        // With this input, for stable sort we expect all 0's to line up before 1's. The expected sort order is same as expected_sort_output
+        let input: Vec<u128> = vec![1, 0, 1, 0, 0, 1, 0];
+        let expected_sort_output = [5_u128, 1, 6, 2, 3, 7, 4];
+
+        let input_len = input.len();
+        let mut shares = [
+            Vec::with_capacity(input_len),
+            Vec::with_capacity(input_len),
+            Vec::with_capacity(input_len),
+        ];
+        for iter in input {
+            let share = share(Fp31::from(iter), &mut rand);
+            for i in 0..3 {
+                shares[i].push(share[i]);
+            }
+        }
+
+        let h0_future = BitPermutations::new(&shares[0]).execute(&context[0]);
+        let h1_future = BitPermutations::new(&shares[1]).execute(&context[1]);
+        let h2_future = BitPermutations::new(&shares[2]).execute(&context[2]);
+
+        let result = try_join!(h0_future, h1_future, h2_future).unwrap();
+
+        assert_eq!(result.0.len(), input_len);
+        assert_eq!(result.1.len(), input_len);
+        assert_eq!(result.2.len(), input_len);
+
+        (0..result.0.len()).for_each(|i| {
+            assert_eq!(
+                validate_and_reconstruct((
+                    result.0[i],
+                    result.1[i],
+                    result.2[i]
+                )),
+                Fp31::from(expected_sort_output[i])
+            );
+        });
+    }
+}

--- a/src/protocol/sort/bit_permutations.rs
+++ b/src/protocol/sort/bit_permutations.rs
@@ -24,54 +24,46 @@ impl<'a, F: Field> BitPermutations<'a, F> {
     /// 1. calculate 1 - x, x and concatenate them
     /// 2. calculate cumulative sum at each vector row
     /// 3. return back tuple of step 1 and step 2 output
+    #[allow(clippy::cast_possible_truncation)]
     fn prepare_mult_inputs<M: Mesh, G: Gateway<M, IPAProtocolStep>>(
         &self,
-        ctx: &ProtocolContext<'_, G, IPAProtocolStep>,
-    ) -> Vec<(Replicated<F>, Replicated<F>)>
+        ctx: &ProtocolContext<'a, G, IPAProtocolStep>,
+    ) -> impl Iterator<Item = (RecordId, (Replicated<F>, Replicated<F>))> + 'a
     where
         F: Field,
     {
-        let channel = ctx
+        let share_of_one = ctx
             .gateway
-            .get_channel(IPAProtocolStep::Sort(SortStep::BitPermutations));
+            .get_channel(IPAProtocolStep::Sort(SortStep::BitPermutations))
+            .share_of_one();
 
         self.input
             .iter()
-            .map(|x| channel.share_of_one() - *x)
+            .map(move |x: &Replicated<F>| share_of_one - *x)
             .chain(self.input.iter().copied())
-            .scan(Replicated::<F>::new(F::ZERO, F::ZERO), |sum, n| {
-                *sum = *sum + n;
-                Some((n, *sum))
+            .enumerate()
+            .scan(Replicated::<F>::new(F::ZERO, F::ZERO), |sum, (index, n)| {
+                *sum += n;
+                Some((RecordId::from(index as u32), (n, *sum)))
             })
-            .collect()
     }
 
     /// multiplies the input vector pairs across helpers and returns result
     /// For this, it spawns all multiplication, wait for them to finish in parallel and then collect the results
-
     #[allow(clippy::cast_possible_truncation)]
     async fn secure_multiply<M: Mesh, G: Gateway<M, IPAProtocolStep>>(
         &self,
-        ctx: &ProtocolContext<'_, G, IPAProtocolStep>,
-        mult_inputs: Vec<(Replicated<F>, Replicated<F>)>,
-    ) -> Result<Vec<Replicated<F>>, BoxError>
+        ctx: &ProtocolContext<'a, G, IPAProtocolStep>,
+        mult_input: (RecordId, (Replicated<F>, Replicated<F>)),
+    ) -> Result<Replicated<F>, BoxError>
     where
         F: Field,
     {
-        let async_multiply = mult_inputs
-            .iter()
-            .enumerate()
-            .map(|(index, input)| async move {
-                ctx.multiply(
-                    RecordId::from(index as u32),
-                    IPAProtocolStep::Sort(SortStep::BitPermutations),
-                )
-                .await
-                .execute(input.0, input.1)
-                .await
-            });
-
-        try_join_all(async_multiply).await
+        let (record_id, share) = mult_input;
+        ctx.multiply(record_id, IPAProtocolStep::Sort(SortStep::BitPermutations))
+            .await
+            .execute(share.0, share.1)
+            .await
     }
 
     /// Executes sorting of a bit column on mpc helpers. Each helper receives their input shares and do following steps
@@ -80,21 +72,23 @@ impl<'a, F: Field> BitPermutations<'a, F> {
     /// 3. add ith column by i+len to obtain helper's share of sorted location, where len is same as input shares length
     #[allow(dead_code)]
     pub async fn execute<M: Mesh, G: Gateway<M, IPAProtocolStep>>(
-        self,
+        &self,
         ctx: &ProtocolContext<'_, G, IPAProtocolStep>,
     ) -> Result<Vec<Replicated<F>>, BoxError>
     where
         F: Field,
     {
         let mult_input = self.prepare_mult_inputs(ctx);
-        assert_eq!(mult_input.len(), self.input.len() * 2);
+        let async_multiply =
+            mult_input.map(|input| async move { self.secure_multiply(ctx, input).await });
+        let mut mult_output = try_join_all(async_multiply).await?;
 
-        let mut mult_output = self.secure_multiply(ctx, mult_input).await?;
         assert_eq!(mult_output.len(), self.input.len() * 2);
         // Generate permutation location
         let len = mult_output.len() / 2;
         for i in 0..len {
-            mult_output[i] = mult_output[i] + mult_output[i + len];
+            let val = mult_output[i + len];
+            mult_output[i] += val;
         }
         mult_output.truncate(len);
 
@@ -109,7 +103,8 @@ mod tests {
 
     use crate::{
         field::Fp31,
-        protocol::{securemul, sort::bit_permutations::BitPermutations, IPAProtocolStep, QueryId}, test_fixture::{make_world,validate_and_reconstruct, TestWorld, make_contexts, share},
+        protocol::{sort::bit_permutations::BitPermutations, IPAProtocolStep, QueryId},
+        test_fixture::{make_contexts, make_world, share, validate_and_reconstruct, TestWorld},
     };
 
     #[tokio::test]
@@ -135,9 +130,12 @@ mod tests {
             }
         }
 
-        let h0_future = BitPermutations::new(&shares[0]).execute(&context[0]);
-        let h1_future = BitPermutations::new(&shares[1]).execute(&context[1]);
-        let h2_future = BitPermutations::new(&shares[2]).execute(&context[2]);
+        let bitperms0 = BitPermutations::new(&shares[0]);
+        let bitperms1 = BitPermutations::new(&shares[1]);
+        let bitperms2 = BitPermutations::new(&shares[2]);
+        let h0_future = bitperms0.execute(&context[0]);
+        let h1_future = bitperms1.execute(&context[1]);
+        let h2_future = bitperms2.execute(&context[2]);
 
         let result = try_join!(h0_future, h1_future, h2_future).unwrap();
 
@@ -147,11 +145,7 @@ mod tests {
 
         (0..result.0.len()).for_each(|i| {
             assert_eq!(
-                validate_and_reconstruct((
-                    result.0[i],
-                    result.1[i],
-                    result.2[i]
-                )),
+                validate_and_reconstruct((result.0[i], result.1[i], result.2[i])),
                 Fp31::from(expected_sort_output[i])
             );
         });

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -1,0 +1,1 @@
+pub mod bit_permutations;

--- a/src/test_fixture/logging.rs
+++ b/src/test_fixture/logging.rs
@@ -1,0 +1,13 @@
+use std::sync::Once;
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+pub fn setup() {
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        tracing_subscriber::registry()
+            .with(EnvFilter::from_default_env())
+            .with(fmt::layer())
+            .init();
+    });
+}

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -1,4 +1,5 @@
 pub mod circuit;
+pub mod logging;
 mod sharing;
 mod world;
 

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -2,6 +2,7 @@ use crate::helpers::mock::TestHelperGateway;
 use crate::helpers::prss::{Participant, SpaceIndex};
 use crate::protocol::{QueryId, Step};
 use crate::test_fixture::make_participants;
+use std::fmt::{Debug, Formatter};
 
 /// Test environment for protocols to run tests that require communication between helpers.
 /// For now the messages sent through it never leave the test infra memory perimeter, so
@@ -28,10 +29,19 @@ pub fn make<S: Step + SpaceIndex>(query_id: QueryId) -> TestWorld<S> {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TestStep {
     Mul1(u8),
     Mul2,
+}
+
+impl Debug for TestStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TestStep::Mul1(v) => write!(f, "TestStep/Mul1[{}]", v),
+            TestStep::Mul2 => write!(f, "TestStep/Mul2"),
+        }
+    }
 }
 
 impl Step for TestStep {}


### PR DESCRIPTION
[Semi honest sort] Computing bit permutations
    Executes sorting of a bit column on mpc helpers. Each helper receives their input shares and do following steps
    1. local computation by `prepare_mult_inputs` which outputs 2 vectors [x,y]
    2. multiply each row of previous output individually (i.e. x*y) across mpc helpers.
    3. add ith column by i+len to obtain helper's share of sorted location, where len is same as input shares length

PS: Have stacked this over the "refactor" branch changes so you would see more changes than needed for this commit