### PR TITLE
Instrument mock module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,9 @@ tokio = { version = "1.19.2", optional = true, features = ["rt", "rt-multi-threa
 tokio-stream = { version = "0.1.9", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.3.4", optional = true, features = ["trace"] }
-tracing = "0.1.35"
-tracing-subscriber = { version = "0.3.14", optional = true }
+# disable debug traces and below for release builds and keep everything for debug build
+tracing = { version = "0.1.35", features = ["max_level_trace", "release_max_level_info"] }
+tracing-subscriber = { version = "0.3.14", optional = true, features = ["env-filter"] }
 x25519-dalek = "2.0.0-pre.1"
 
 [dev-dependencies]

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "http" => BindTarget::Http(addr),
         #[cfg(feature = "self-signed-certs")]
         "https" => {
-            let config = raw_ipa::net::tls_config_from_self_signed_cert().await?;
+            let config = raw_ipa::cli::net::tls_config_from_self_signed_cert().await?;
             BindTarget::Https(addr, config)
         }
         _ => {

--- a/src/helpers/mock.rs
+++ b/src/helpers/mock.rs
@@ -9,9 +9,12 @@ use futures_util::stream::SelectAll;
 use futures_util::StreamExt;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex};
+
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
+use tracing::Instrument;
 
 /// Gateway is just the proxy for `Controller` interface to provide stable API and hide
 /// `Controller`'s dependencies
@@ -32,7 +35,6 @@ pub struct TestMesh<S> {
 }
 
 /// Represents control messages sent between helpers to handle infrastructure requests.
-#[derive(Debug)]
 enum ControlMessage<S> {
     /// Connection for step S is requested by the peer
     ConnectionRequest(Identity, S, mpsc::Receiver<MessageEnvelope>),
@@ -66,7 +68,6 @@ enum BufItem {
     Received(Box<[u8]>),
 }
 
-#[derive(Debug)]
 struct ReceiveRequest<S> {
     from: Identity,
     step: S,
@@ -166,6 +167,7 @@ impl<S: Step> Gateway<TestMesh<S>, S> for TestHelperGateway<S> {
 
 #[async_trait]
 impl<S: Step> Mesh for TestMesh<S> {
+    #[tracing::instrument(skip(self), level = "trace")]
     async fn send<T: Message>(
         &mut self,
         target: Identity,
@@ -188,13 +190,11 @@ impl<S: Step> Mesh for TestMesh<S> {
         Ok(())
     }
 
-    async fn receive<T: Message>(
-        &mut self,
-        source: Identity,
-        record: RecordId,
-    ) -> Result<T, Error> {
-        let payload = self.controller.receive(source, self.step, record).await;
+    #[tracing::instrument(skip(self), fields(identity=?self.controller.identity, step=?self.step), level="trace")]
+    async fn receive<T: Message>(&mut self, from: Identity, record: RecordId) -> Result<T, Error> {
+        let payload = self.controller.receive(from, self.step, record).await;
         let obj: T = serde_json::from_slice(&payload).unwrap();
+        tracing::trace!("message received: {obj:?}");
 
         Ok(obj)
     }
@@ -229,12 +229,13 @@ impl<S: Step> Controller<S> {
             peers: control_tx,
         };
 
-        Controller::start(control_rx, receive_rx);
+        Controller::start(identity, control_rx, receive_rx);
 
         controller
     }
 
     fn start(
+        identity: Identity,
         mut control_rx: mpsc::Receiver<ControlMessage<S>>,
         mut receive_rx: mpsc::Receiver<ReceiveRequest<S>>,
     ) {
@@ -249,6 +250,7 @@ impl<S: Step> Controller<S> {
                 // * Handle the request to receive a message from another helper
                 tokio::select! {
                     Some(control_message) = control_rx.recv() => {
+                        tracing::debug!("new {control_message:?}");
                         match control_message {
                             ControlMessage::ConnectionRequest(peer, step, peer_connection) => {
                                 channels.push(prepend((peer, step), ReceiverStream::new(peer_connection)));
@@ -256,23 +258,27 @@ impl<S: Step> Controller<S> {
                         }
                     }
                     Some(receive_request) = receive_rx.recv() => {
+                        tracing::trace!("new {:?}", receive_request);
                         buf.entry(receive_request.channel_id())
                            .or_default()
                            .receive_request(receive_request.record_id, receive_request.sender);
                     }
                     Some(((from_peer, step), message_envelope)) = channels.next() => {
+                        tracing::trace!("new MessageArrival(from={from_peer:?}, step={step:?}, record={:?}, size={}B)", message_envelope.record_id, message_envelope.payload.len());
                         buf.entry((from_peer, step))
                            .or_default()
                            .receive_message(message_envelope);
                     }
                     else => {
+                        tracing::debug!("All channels are closed and event loop is terminated");
                         break;
                     }
                 }
             }
-        });
+        }.instrument(tracing::info_span!("helper_event_loop", identity=?identity)));
     }
 
+    #[tracing::instrument(skip(self), level = "trace")]
     async fn get_connection(&self, peer: Identity, step: S) -> mpsc::Sender<MessageEnvelope> {
         assert_ne!(self.identity, peer);
 
@@ -288,6 +294,7 @@ impl<S: Step> Controller<S> {
         };
 
         if let Some(rx) = rx {
+            tracing::trace!("Requesting connection");
             self.peers
                 .get(&peer)
                 .expect("peer with id {peer:?} should exist")
@@ -335,4 +342,24 @@ fn make_controllers<S: Step>() -> [Controller<S>; 3] {
 
 pub fn prepend<T: Copy + Clone, S: Stream>(id: T, stream: S) -> impl Stream<Item = (T, S::Item)> {
     stream.map(move |item| (id, item))
+}
+
+impl<S: Step> Debug for ControlMessage<S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ControlMessage::ConnectionRequest(from, step, _) => {
+                write!(f, "ConnectionRequest(from={:?}, step={:?})", from, step)
+            }
+        }
+    }
+}
+
+impl<S: Step> Debug for ReceiveRequest<S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ReceiveRequest(from={:?}, step={:?}, record={:?})",
+            self.from, self.step, self.record_id
+        )
+    }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,7 +1,7 @@
 pub mod context;
 mod securemul;
 
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 
 /// Defines a unique step of the IPA protocol. Step is a transformation that takes an input
@@ -24,19 +24,40 @@ use std::hash::Hash;
 pub trait Step: Copy + Clone + Debug + Eq + Hash + Send + 'static {}
 
 /// Set of steps that define the IPA protocol.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum IPAProtocolStep {
     /// Convert from XOR shares to Replicated shares
-    ConvertShares(ShareConversionStep),
+    ConvertShares,
     /// Sort shares by the match key
     Sort(SortStep),
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum ShareConversionStep {}
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum SortStep {
+    GenBitPermutations,
+}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum SortStep {}
+impl Debug for IPAProtocolStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IPA/")?;
+        match self {
+            IPAProtocolStep::ConvertShares => {
+                write!(f, "ConvertShares")
+            }
+            IPAProtocolStep::Sort(sort_step) => {
+                write!(f, "Sort/{:?}", sort_step)
+            }
+        }
+    }
+}
+
+impl Debug for SortStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SortStep::GenBitPermutations => write!(f, "GenBitPermutations"),
+        }
+    }
+}
 
 impl Step for IPAProtocolStep {}
 

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -158,7 +158,7 @@ pub mod stream {
         use crate::protocol::securemul::stream::secure_multiply;
         use crate::protocol::QueryId;
         use crate::secret_sharing::Replicated;
-        use crate::test_fixture::{make_world, share, validate_and_reconstruct};
+        use crate::test_fixture::{logging, make_world, share, validate_and_reconstruct};
         use futures::StreamExt;
         use futures_util::future::join_all;
         use futures_util::stream;
@@ -168,6 +168,9 @@ pub mod stream {
         /// of a `Stream`.
         #[tokio::test]
         async fn supports_stream_of_secret_shares() {
+            // https://github.com/rust-lang/rfcs/issues/1664
+            logging::setup();
+
             // we compute a*b*c in this test. 4*3*2 = 24
             let mut rand = StepRng::new(1, 1);
             let a = share(Fp31::from(4_u128), &mut rand);
@@ -216,7 +219,7 @@ pub mod stream {
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     use crate::field::{Field, Fp31};
@@ -233,11 +236,12 @@ pub mod tests {
     use crate::helpers::mock::TestHelperGateway;
     use crate::protocol::{QueryId, RecordId};
     use crate::test_fixture::{
-        make_contexts, make_world, share, validate_and_reconstruct, TestStep,
+        logging, make_contexts, make_world, share, validate_and_reconstruct, TestStep,
     };
 
     #[tokio::test]
     async fn basic() -> Result<(), BoxError> {
+        logging::setup();
         let world = make_world(QueryId);
         let context = make_contexts(&world);
         let mut rand = StepRng::new(1, 1);
@@ -260,6 +264,8 @@ pub mod tests {
     #[tokio::test]
     #[allow(clippy::cast_possible_truncation)]
     pub async fn concurrent_mul() {
+        logging::setup();
+
         let world = make_world(QueryId);
         let context = make_contexts(&world);
         let mut rand = StepRng::new(1, 1);

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -168,7 +168,7 @@ pub mod stream {
         /// of a `Stream`.
         #[tokio::test]
         async fn supports_stream_of_secret_shares() {
-            // https://github.com/rust-lang/rfcs/issues/1664
+            // beforeEach is not a thing in Rust yet: https://github.com/rust-lang/rfcs/issues/1664
             logging::setup();
 
             // we compute a*b*c in this test. 4*3*2 = 24

--- a/src/test_fixture/logging.rs
+++ b/src/test_fixture/logging.rs
@@ -1,0 +1,13 @@
+use std::sync::Once;
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+pub fn setup() {
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        tracing_subscriber::registry()
+            .with(EnvFilter::from_default_env())
+            .with(fmt::layer())
+            .init();
+    });
+}

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -1,4 +1,5 @@
 pub mod circuit;
+pub mod logging;
 mod sharing;
 mod world;
 

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -2,6 +2,7 @@ use crate::helpers::mock::TestHelperGateway;
 use crate::helpers::prss::{Participant, SpaceIndex};
 use crate::protocol::{QueryId, Step};
 use crate::test_fixture::make_participants;
+use std::fmt::{Debug, Formatter};
 
 /// Test environment for protocols to run tests that require communication between helpers.
 /// For now the messages sent through it never leave the test infra memory perimeter, so
@@ -28,10 +29,19 @@ pub fn make<S: Step + SpaceIndex>(query_id: QueryId) -> TestWorld<S> {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TestStep {
     Mul1(u8),
     Mul2,
+}
+
+impl Debug for TestStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TestStep::Mul1(v) => write!(f, "TestStep/Mul1[{}]", v),
+            TestStep::Mul2 => write!(f, "TestStep/Mul2"),
+        }
+    }
 }
 
 impl Step for TestStep {}


### PR DESCRIPTION
Add traces to various code blocks inside this module to improve traceability.

Implement logging setup for tests and use it inside securemul.rs. Trace level can be controlled by setting `RUST_LOG` variable

```bash
RUST_LOG=trace && cargo test
```

### Example

```
2022-09-20T01:27:34.860994Z TRACE send{target=H2 record_id=RecordId(1) msg=DValue { d: 2_mod31 }}:get_connection{peer=H2 step=TestStep/Mul1[1]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862044Z TRACE send{target=H3 record_id=RecordId(1) msg=DValue { d: 11_mod31 }}:get_connection{peer=H3 step=TestStep/Mul1[1]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862148Z TRACE send{target=H1 record_id=RecordId(1) msg=DValue { d: 22_mod31 }}:get_connection{peer=H1 step=TestStep/Mul1[1]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862249Z TRACE send{target=H2 record_id=RecordId(1) msg=DValue { d: 2_mod31 }}:get_connection{peer=H2 step=TestStep/Mul1[2]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862323Z TRACE send{target=H3 record_id=RecordId(1) msg=DValue { d: 11_mod31 }}:get_connection{peer=H3 step=TestStep/Mul1[2]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862394Z TRACE send{target=H1 record_id=RecordId(1) msg=DValue { d: 22_mod31 }}:get_connection{peer=H1 step=TestStep/Mul1[2]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862466Z TRACE send{target=H2 record_id=RecordId(1) msg=DValue { d: 2_mod31 }}:get_connection{peer=H2 step=TestStep/Mul1[3]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862535Z TRACE send{target=H3 record_id=RecordId(1) msg=DValue { d: 11_mod31 }}:get_connection{peer=H3 step=TestStep/Mul1[3]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862604Z TRACE send{target=H1 record_id=RecordId(1) msg=DValue { d: 22_mod31 }}:get_connection{peer=H1 step=TestStep/Mul1[3]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862679Z TRACE send{target=H2 record_id=RecordId(1) msg=DValue { d: 2_mod31 }}:get_connection{peer=H2 step=TestStep/Mul1[4]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862749Z TRACE send{target=H3 record_id=RecordId(1) msg=DValue { d: 11_mod31 }}:get_connection{peer=H3 step=TestStep/Mul1[4]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862820Z TRACE send{target=H1 record_id=RecordId(1) msg=DValue { d: 22_mod31 }}:get_connection{peer=H1 step=TestStep/Mul1[4]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862892Z TRACE send{target=H2 record_id=RecordId(1) msg=DValue { d: 2_mod31 }}:get_connection{peer=H2 step=TestStep/Mul1[5]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.862962Z TRACE send{target=H3 record_id=RecordId(1) msg=DValue { d: 11_mod31 }}:get_connection{peer=H3 step=TestStep/Mul1[5]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863030Z TRACE send{target=H1 record_id=RecordId(1) msg=DValue { d: 22_mod31 }}:get_connection{peer=H1 step=TestStep/Mul1[5]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863098Z TRACE send{target=H2 record_id=RecordId(1) msg=DValue { d: 2_mod31 }}:get_connection{peer=H2 step=TestStep/Mul1[6]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863183Z TRACE send{target=H3 record_id=RecordId(1) msg=DValue { d: 11_mod31 }}:get_connection{peer=H3 step=TestStep/Mul1[6]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863250Z TRACE send{target=H1 record_id=RecordId(1) msg=DValue { d: 22_mod31 }}:get_connection{peer=H1 step=TestStep/Mul1[6]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863319Z TRACE send{target=H2 record_id=RecordId(1) msg=DValue { d: 2_mod31 }}:get_connection{peer=H2 step=TestStep/Mul1[7]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863387Z TRACE send{target=H3 record_id=RecordId(1) msg=DValue { d: 11_mod31 }}:get_connection{peer=H3 step=TestStep/Mul1[7]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863455Z TRACE send{target=H1 record_id=RecordId(1) msg=DValue { d: 22_mod31 }}:get_connection{peer=H1 step=TestStep/Mul1[7]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863528Z TRACE send{target=H2 record_id=RecordId(1) msg=DValue { d: 2_mod31 }}:get_connection{peer=H2 step=TestStep/Mul1[8]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863620Z TRACE send{target=H3 record_id=RecordId(1) msg=DValue { d: 11_mod31 }}:get_connection{peer=H3 step=TestStep/Mul1[8]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863740Z TRACE send{target=H1 record_id=RecordId(1) msg=DValue { d: 22_mod31 }}:get_connection{peer=H1 step=TestStep/Mul1[8]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863826Z TRACE send{target=H2 record_id=RecordId(1) msg=DValue { d: 2_mod31 }}:get_connection{peer=H2 step=TestStep/Mul1[9]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863901Z TRACE send{target=H3 record_id=RecordId(1) msg=DValue { d: 11_mod31 }}:get_connection{peer=H3 step=TestStep/Mul1[9]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.863973Z TRACE send{target=H1 record_id=RecordId(1) msg=DValue { d: 22_mod31 }}:get_connection{peer=H1 step=TestStep/Mul1[9]}: raw_ipa::helpers::mock: Requesting connection
2022-09-20T01:27:34.865461Z DEBUG helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ConnectionRequest(from=H3, step=TestStep/Mul1[1])
2022-09-20T01:27:34.865489Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ReceiveRequest(from=H3, step=TestStep/Mul1[1], record=RecordId(1))
2022-09-20T01:27:34.865691Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new MessageArrival(from=H3, step=TestStep/Mul1[1], record=RecordId(1), size=8B)
2022-09-20T01:27:34.865920Z DEBUG helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ConnectionRequest(from=H1, step=TestStep/Mul1[1])
2022-09-20T01:27:34.865937Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ReceiveRequest(from=H1, step=TestStep/Mul1[1], record=RecordId(1))
2022-09-20T01:27:34.865963Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new MessageArrival(from=H1, step=TestStep/Mul1[1], record=RecordId(1), size=7B)
2022-09-20T01:27:34.865994Z DEBUG helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ConnectionRequest(from=H2, step=TestStep/Mul1[1])
2022-09-20T01:27:34.866009Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ReceiveRequest(from=H2, step=TestStep/Mul1[1], record=RecordId(1))
2022-09-20T01:27:34.866030Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new MessageArrival(from=H2, step=TestStep/Mul1[1], record=RecordId(1), size=8B)
2022-09-20T01:27:34.866134Z TRACE receive{from=H1 record=RecordId(1) identity=H2 step=TestStep/Mul1[1]}: raw_ipa::helpers::mock: message received: DValue { d: 2_mod31 }
2022-09-20T01:27:34.866167Z TRACE receive{from=H2 record=RecordId(1) identity=H3 step=TestStep/Mul1[1]}: raw_ipa::helpers::mock: message received: DValue { d: 11_mod31 }
2022-09-20T01:27:34.866188Z TRACE receive{from=H3 record=RecordId(1) identity=H1 step=TestStep/Mul1[1]}: raw_ipa::helpers::mock: message received: DValue { d: 22_mod31 }
2022-09-20T01:27:34.866416Z DEBUG helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ConnectionRequest(from=H2, step=TestStep/Mul1[2])
2022-09-20T01:27:34.866431Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ReceiveRequest(from=H2, step=TestStep/Mul1[2], record=RecordId(1))
2022-09-20T01:27:34.866451Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new MessageArrival(from=H2, step=TestStep/Mul1[2], record=RecordId(1), size=8B)
2022-09-20T01:27:34.866475Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ReceiveRequest(from=H1, step=TestStep/Mul1[2], record=RecordId(1))
2022-09-20T01:27:34.866492Z DEBUG helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ConnectionRequest(from=H1, step=TestStep/Mul1[2])
2022-09-20T01:27:34.866508Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new MessageArrival(from=H1, step=TestStep/Mul1[2], record=RecordId(1), size=7B)
2022-09-20T01:27:34.866530Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ReceiveRequest(from=H3, step=TestStep/Mul1[2], record=RecordId(1))
2022-09-20T01:27:34.866547Z DEBUG helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ConnectionRequest(from=H3, step=TestStep/Mul1[2])
2022-09-20T01:27:34.866563Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new MessageArrival(from=H3, step=TestStep/Mul1[2], record=RecordId(1), size=8B)
2022-09-20T01:27:34.866591Z TRACE receive{from=H2 record=RecordId(1) identity=H3 step=TestStep/Mul1[2]}: raw_ipa::helpers::mock: message received: DValue { d: 11_mod31 }
2022-09-20T01:27:34.866611Z TRACE receive{from=H3 record=RecordId(1) identity=H1 step=TestStep/Mul1[2]}: raw_ipa::helpers::mock: message received: DValue { d: 22_mod31 }
2022-09-20T01:27:34.866630Z TRACE receive{from=H1 record=RecordId(1) identity=H2 step=TestStep/Mul1[2]}: raw_ipa::helpers::mock: message received: DValue { d: 2_mod31 }
2022-09-20T01:27:34.866818Z DEBUG helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ConnectionRequest(from=H3, step=TestStep/Mul1[3])
2022-09-20T01:27:34.866833Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ReceiveRequest(from=H3, step=TestStep/Mul1[3], record=RecordId(1))
2022-09-20T01:27:34.866887Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new MessageArrival(from=H3, step=TestStep/Mul1[3], record=RecordId(1), size=8B)
2022-09-20T01:27:34.866912Z DEBUG helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ConnectionRequest(from=H2, step=TestStep/Mul1[3])
2022-09-20T01:27:34.866926Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ReceiveRequest(from=H2, step=TestStep/Mul1[3], record=RecordId(1))
2022-09-20T01:27:34.866944Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new MessageArrival(from=H2, step=TestStep/Mul1[3], record=RecordId(1), size=8B)
2022-09-20T01:27:34.866968Z DEBUG helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ConnectionRequest(from=H1, step=TestStep/Mul1[3])
2022-09-20T01:27:34.866984Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new MessageArrival(from=H1, step=TestStep/Mul1[3], record=RecordId(1), size=7B)
2022-09-20T01:27:34.866999Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ReceiveRequest(from=H1, step=TestStep/Mul1[3], record=RecordId(1))
2022-09-20T01:27:34.867028Z TRACE receive{from=H3 record=RecordId(1) identity=H1 step=TestStep/Mul1[3]}: raw_ipa::helpers::mock: message received: DValue { d: 22_mod31 }
2022-09-20T01:27:34.867048Z TRACE receive{from=H1 record=RecordId(1) identity=H2 step=TestStep/Mul1[3]}: raw_ipa::helpers::mock: message received: DValue { d: 2_mod31 }
2022-09-20T01:27:34.867067Z TRACE receive{from=H2 record=RecordId(1) identity=H3 step=TestStep/Mul1[3]}: raw_ipa::helpers::mock: message received: DValue { d: 11_mod31 }
2022-09-20T01:27:34.867240Z DEBUG helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ConnectionRequest(from=H1, step=TestStep/Mul1[4])
2022-09-20T01:27:34.867257Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new MessageArrival(from=H1, step=TestStep/Mul1[4], record=RecordId(1), size=7B)
2022-09-20T01:27:34.867276Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ReceiveRequest(from=H1, step=TestStep/Mul1[4], record=RecordId(1))
2022-09-20T01:27:34.867300Z DEBUG helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ConnectionRequest(from=H3, step=TestStep/Mul1[4])
2022-09-20T01:27:34.867315Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ReceiveRequest(from=H3, step=TestStep/Mul1[4], record=RecordId(1))
2022-09-20T01:27:34.867336Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new MessageArrival(from=H3, step=TestStep/Mul1[4], record=RecordId(1), size=8B)
2022-09-20T01:27:34.867360Z DEBUG helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ConnectionRequest(from=H2, step=TestStep/Mul1[4])
2022-09-20T01:27:34.867374Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ReceiveRequest(from=H2, step=TestStep/Mul1[4], record=RecordId(1))
2022-09-20T01:27:34.867394Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new MessageArrival(from=H2, step=TestStep/Mul1[4], record=RecordId(1), size=8B)
2022-09-20T01:27:34.867422Z TRACE receive{from=H1 record=RecordId(1) identity=H2 step=TestStep/Mul1[4]}: raw_ipa::helpers::mock: message received: DValue { d: 2_mod31 }
2022-09-20T01:27:34.867442Z TRACE receive{from=H2 record=RecordId(1) identity=H3 step=TestStep/Mul1[4]}: raw_ipa::helpers::mock: message received: DValue { d: 11_mod31 }
2022-09-20T01:27:34.867461Z TRACE receive{from=H3 record=RecordId(1) identity=H1 step=TestStep/Mul1[4]}: raw_ipa::helpers::mock: message received: DValue { d: 22_mod31 }
2022-09-20T01:27:34.867621Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ReceiveRequest(from=H2, step=TestStep/Mul1[5], record=RecordId(1))
2022-09-20T01:27:34.867640Z DEBUG helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ConnectionRequest(from=H2, step=TestStep/Mul1[5])
2022-09-20T01:27:34.867657Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new MessageArrival(from=H2, step=TestStep/Mul1[5], record=RecordId(1), size=8B)
2022-09-20T01:27:34.867681Z DEBUG helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ConnectionRequest(from=H1, step=TestStep/Mul1[5])
2022-09-20T01:27:34.867695Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ReceiveRequest(from=H1, step=TestStep/Mul1[5], record=RecordId(1))
2022-09-20T01:27:34.867712Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new MessageArrival(from=H1, step=TestStep/Mul1[5], record=RecordId(1), size=7B)
2022-09-20T01:27:34.867735Z DEBUG helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ConnectionRequest(from=H3, step=TestStep/Mul1[5])
2022-09-20T01:27:34.867749Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ReceiveRequest(from=H3, step=TestStep/Mul1[5], record=RecordId(1))
2022-09-20T01:27:34.867766Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new MessageArrival(from=H3, step=TestStep/Mul1[5], record=RecordId(1), size=8B)
2022-09-20T01:27:34.867794Z TRACE receive{from=H2 record=RecordId(1) identity=H3 step=TestStep/Mul1[5]}: raw_ipa::helpers::mock: message received: DValue { d: 11_mod31 }
2022-09-20T01:27:34.867813Z TRACE receive{from=H3 record=RecordId(1) identity=H1 step=TestStep/Mul1[5]}: raw_ipa::helpers::mock: message received: DValue { d: 22_mod31 }
2022-09-20T01:27:34.867832Z TRACE receive{from=H1 record=RecordId(1) identity=H2 step=TestStep/Mul1[5]}: raw_ipa::helpers::mock: message received: DValue { d: 2_mod31 }
2022-09-20T01:27:34.867980Z DEBUG helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ConnectionRequest(from=H3, step=TestStep/Mul1[6])
2022-09-20T01:27:34.867995Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ReceiveRequest(from=H3, step=TestStep/Mul1[6], record=RecordId(1))
2022-09-20T01:27:34.868013Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new MessageArrival(from=H3, step=TestStep/Mul1[6], record=RecordId(1), size=8B)
2022-09-20T01:27:34.868036Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ReceiveRequest(from=H2, step=TestStep/Mul1[6], record=RecordId(1))
2022-09-20T01:27:34.868053Z DEBUG helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ConnectionRequest(from=H2, step=TestStep/Mul1[6])
2022-09-20T01:27:34.868069Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new MessageArrival(from=H2, step=TestStep/Mul1[6], record=RecordId(1), size=8B)
2022-09-20T01:27:34.868091Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ReceiveRequest(from=H1, step=TestStep/Mul1[6], record=RecordId(1))
2022-09-20T01:27:34.868109Z DEBUG helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ConnectionRequest(from=H1, step=TestStep/Mul1[6])
2022-09-20T01:27:34.868124Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new MessageArrival(from=H1, step=TestStep/Mul1[6], record=RecordId(1), size=7B)
2022-09-20T01:27:34.868152Z TRACE receive{from=H3 record=RecordId(1) identity=H1 step=TestStep/Mul1[6]}: raw_ipa::helpers::mock: message received: DValue { d: 22_mod31 }
2022-09-20T01:27:34.868171Z TRACE receive{from=H1 record=RecordId(1) identity=H2 step=TestStep/Mul1[6]}: raw_ipa::helpers::mock: message received: DValue { d: 2_mod31 }
2022-09-20T01:27:34.868190Z TRACE receive{from=H2 record=RecordId(1) identity=H3 step=TestStep/Mul1[6]}: raw_ipa::helpers::mock: message received: DValue { d: 11_mod31 }
2022-09-20T01:27:34.868324Z DEBUG helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ConnectionRequest(from=H1, step=TestStep/Mul1[7])
2022-09-20T01:27:34.868339Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ReceiveRequest(from=H1, step=TestStep/Mul1[7], record=RecordId(1))
2022-09-20T01:27:34.868356Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new MessageArrival(from=H1, step=TestStep/Mul1[7], record=RecordId(1), size=7B)
2022-09-20T01:27:34.868380Z DEBUG helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ConnectionRequest(from=H3, step=TestStep/Mul1[7])
2022-09-20T01:27:34.868393Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ReceiveRequest(from=H3, step=TestStep/Mul1[7], record=RecordId(1))
2022-09-20T01:27:34.868412Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new MessageArrival(from=H3, step=TestStep/Mul1[7], record=RecordId(1), size=8B)
2022-09-20T01:27:34.868434Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ReceiveRequest(from=H2, step=TestStep/Mul1[7], record=RecordId(1))
2022-09-20T01:27:34.868451Z DEBUG helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ConnectionRequest(from=H2, step=TestStep/Mul1[7])
2022-09-20T01:27:34.868467Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new MessageArrival(from=H2, step=TestStep/Mul1[7], record=RecordId(1), size=8B)
2022-09-20T01:27:34.868495Z TRACE receive{from=H1 record=RecordId(1) identity=H2 step=TestStep/Mul1[7]}: raw_ipa::helpers::mock: message received: DValue { d: 2_mod31 }
2022-09-20T01:27:34.868514Z TRACE receive{from=H2 record=RecordId(1) identity=H3 step=TestStep/Mul1[7]}: raw_ipa::helpers::mock: message received: DValue { d: 11_mod31 }
2022-09-20T01:27:34.868533Z TRACE receive{from=H3 record=RecordId(1) identity=H1 step=TestStep/Mul1[7]}: raw_ipa::helpers::mock: message received: DValue { d: 22_mod31 }
2022-09-20T01:27:34.868655Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ReceiveRequest(from=H2, step=TestStep/Mul1[8], record=RecordId(1))
2022-09-20T01:27:34.868676Z DEBUG helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ConnectionRequest(from=H2, step=TestStep/Mul1[8])
2022-09-20T01:27:34.868692Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new MessageArrival(from=H2, step=TestStep/Mul1[8], record=RecordId(1), size=8B)
2022-09-20T01:27:34.868715Z DEBUG helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ConnectionRequest(from=H1, step=TestStep/Mul1[8])
2022-09-20T01:27:34.868730Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ReceiveRequest(from=H1, step=TestStep/Mul1[8], record=RecordId(1))
2022-09-20T01:27:34.868751Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new MessageArrival(from=H1, step=TestStep/Mul1[8], record=RecordId(1), size=7B)
2022-09-20T01:27:34.868774Z DEBUG helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ConnectionRequest(from=H3, step=TestStep/Mul1[8])
2022-09-20T01:27:34.868788Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ReceiveRequest(from=H3, step=TestStep/Mul1[8], record=RecordId(1))
2022-09-20T01:27:34.868809Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new MessageArrival(from=H3, step=TestStep/Mul1[8], record=RecordId(1), size=8B)
2022-09-20T01:27:34.868837Z TRACE receive{from=H2 record=RecordId(1) identity=H3 step=TestStep/Mul1[8]}: raw_ipa::helpers::mock: message received: DValue { d: 11_mod31 }
2022-09-20T01:27:34.868857Z TRACE receive{from=H3 record=RecordId(1) identity=H1 step=TestStep/Mul1[8]}: raw_ipa::helpers::mock: message received: DValue { d: 22_mod31 }
2022-09-20T01:27:34.868876Z TRACE receive{from=H1 record=RecordId(1) identity=H2 step=TestStep/Mul1[8]}: raw_ipa::helpers::mock: message received: DValue { d: 2_mod31 }
2022-09-20T01:27:34.868984Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ReceiveRequest(from=H3, step=TestStep/Mul1[9], record=RecordId(1))
2022-09-20T01:27:34.869001Z DEBUG helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new ConnectionRequest(from=H3, step=TestStep/Mul1[9])
2022-09-20T01:27:34.869016Z TRACE helper_event_loop{identity=H1}: raw_ipa::helpers::mock: new MessageArrival(from=H3, step=TestStep/Mul1[9], record=RecordId(1), size=8B)
2022-09-20T01:27:34.869039Z DEBUG helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ConnectionRequest(from=H2, step=TestStep/Mul1[9])
2022-09-20T01:27:34.869054Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new MessageArrival(from=H2, step=TestStep/Mul1[9], record=RecordId(1), size=8B)
2022-09-20T01:27:34.869072Z TRACE helper_event_loop{identity=H3}: raw_ipa::helpers::mock: new ReceiveRequest(from=H2, step=TestStep/Mul1[9], record=RecordId(1))
2022-09-20T01:27:34.869093Z DEBUG helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ConnectionRequest(from=H1, step=TestStep/Mul1[9])
2022-09-20T01:27:34.869106Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new ReceiveRequest(from=H1, step=TestStep/Mul1[9], record=RecordId(1))
2022-09-20T01:27:34.869124Z TRACE helper_event_loop{identity=H2}: raw_ipa::helpers::mock: new MessageArrival(from=H1, step=TestStep/Mul1[9], record=RecordId(1), size=7B)
2022-09-20T01:27:34.869151Z TRACE receive{from=H3 record=RecordId(1) identity=H1 step=TestStep/Mul1[9]}: raw_ipa::helpers::mock: message received: DValue { d: 22_mod31 }
2022-09-20T01:27:34.869171Z TRACE receive{from=H1 record=RecordId(1) identity=H2 step=TestStep/Mul1[9]}: raw_ipa::helpers::mock: message received: DValue { d: 2_mod31 }
2022-09-20T01:27:34.869189Z TRACE receive{from=H2 record=RecordId(1) identity=H3 step=TestStep/Mul1[9]}: raw_ipa::helpers::mock: message received: DValue { d: 11_mod31 }
```