### PR TITLE
Fix new clippy warnings

### DIFF
--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -24,6 +24,7 @@ impl<'a, G, S: Step + SpaceIndex> ProtocolContext<'a, G, S> {
     /// to allow backpressure if infrastructure layer cannot keep up with protocols demand.
     /// In this case, function returns only when multiplication for this record can actually
     /// be processed.
+    #[allow(clippy::unused_async)] // eventually there will be await b/c of backpressure implementation
     pub async fn multiply(&'a self, record_id: RecordId, step: S) -> SecureMul<'a, G, S> {
         SecureMul::new(&self.participant[step], self.gateway, step, record_id)
     }


### PR DESCRIPTION
Rust 1.64 brought new Clippy warnings, this change addresses them.