### PR TITLE
Cargo.toml: remove unused deps, bump versions, etc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,25 +15,24 @@ test-fixture = []
 
 [dependencies]
 aes = "0.8"
-async-trait = "0.1.56"
+async-trait = "0.1.57"
 axum = { version = "0.5.16", optional = true, features = ["http2"] }
 axum-server = { version = "0.4.2", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
-byteorder = "1"
+byteorder = "1.4.3"
 clap = { version = "4.0.10", optional = true, features = ["derive"] }
 comfy-table = { version = "6.0.0", optional = true }
 embed-doc-image = "0.1.4"
-futures = "0.3.21"
-futures-util = "0.3.21"
-
+futures = "0.3.24"
+futures-util = "0.3.24"
 hex = { version = "0.4", optional = true }
 hkdf = "0.12.3"
-hyper = { version = "0.14.19", optional = true, features = ["client", "h2"] }
+hyper = { version = "0.14.20", optional = true, features = ["client", "h2"] }
 hyper-tls = { version = "0.5.0", optional = true }
-metrics = "0.19.0"
-metrics-tracing-context = { version = "0.11.0", optional = true }
-metrics-util = { version = "0.13.0", optional = true }
-permutation = "0.3.0"
-pin-project = "1.0.11"
+metrics = "0.20.1"
+metrics-tracing-context = { version = "0.12.0", optional = true }
+metrics-util = { version = "0.14.0", optional = true }
+permutation = "0.4.1"
+pin-project = "1.0.12"
 rand = "0.8"
 rand_chacha = "0.3.1"
 rand_core = "0.6"
@@ -45,12 +44,12 @@ serde_json = { version = "1.0", optional = true }
 sha2 = "0.10.6"
 thiserror = "1.0"
 tokio = { version = "1.19.2", optional = true, features = ["rt", "rt-multi-thread", "macros"] }
-tokio-stream = { version = "0.1.9", optional = true }
+tokio-stream = { version = "0.1.10", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.3.4", optional = true, features = ["trace"] }
 # disable debug traces and below for release builds and keep everything for debug build
-tracing = { version = "0.1.35", features = ["max_level_trace", "release_max_level_info"] }
-tracing-subscriber = { version = "0.3.14", optional = true, features = ["env-filter"] }
+tracing = { version = "0.1.37", features = ["max_level_trace", "release_max_level_info"] }
+tracing-subscriber = { version = "0.3.16", optional = true, features = ["env-filter"] }
 x25519-dalek = "2.0.0-pre.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 sha2 = "0.10.6"
 thiserror = "1.0"
-tokio = { version = "1.19.2", optional = true, features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.21.2", optional = true, features = ["rt", "rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1.10", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.3.4", optional = true, features = ["trace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "raw-ipa"
 version = "0.1.0"
-rust-version = "1.62.0"
+rust-version = "1.64.0"
 edition = "2021"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ permutation = "0.4.1"
 pin-project = "1.0.12"
 rand = "0.8"
 rand_chacha = "0.3.1"
-rand_distr = "0.4.3"
 
 # TODO consider using zerocopy or serde_bytes or in-house serialization
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ x25519-dalek = "2.0.0-pre.1"
 criterion = { version = "0.4.0", default-features = false, features = ["async_tokio", "plotters", "html_reports"] }
 hex = "0.4"
 iai = "0.1.1"
-lazy_static = "1.4.0"
 proptest = "1.0.0"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ test-fixture = []
 [dependencies]
 aes = "0.8"
 async-trait = "0.1.56"
-axum = { version = "0.5.7", optional = true, features = ["http2"] }
-axum-server = { version = "0.4.0", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
+axum = { version = "0.5.16", optional = true, features = ["http2"] }
+axum-server = { version = "0.4.2", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
 byteorder = "1"
 clap = { version = "4.0.10", optional = true, features = ["derive"] }
 comfy-table = { version = "6.0.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ axum-server = { version = "0.4.0", optional = true, features = ["rustls", "rustl
 byteorder = "1"
 clap = { version = "4.0.10", optional = true, features = ["derive"] }
 comfy-table = { version = "6.0.0", optional = true }
-# rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, not 0.10
-digest = "0.9"
 embed-doc-image = "0.1.4"
 futures = "0.3.21"
 futures-util = "0.3.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 default = ["debug", "cli"]
 cli = ["comfy-table", "clap", "enable-serde", "metrics-tracing-context", "metrics-util", "tracing-subscriber", "web-app"]
 debug = ["hex"]
-enable-serde = ["serde", "serde_json", "rust-elgamal/enable-serde"]
+enable-serde = ["serde", "serde_json"]
 web-app = ["tokio", "tokio-stream", "axum", "axum-server", "hyper", "hyper-tls", "tower", "tower-http"]
 self-signed-certs = ["hyper-tls"]
 test-fixture = []
@@ -41,8 +41,9 @@ rand = "0.8"
 rand_chacha = "0.3.1"
 rand_core = "0.6"
 rand_distr = "0.4.3"
-rust-elgamal = "0.4"
-serde = { version = "1.0", optional = true }
+
+# TODO consider using zerocopy or serde_bytes or in-house serialization
+serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 # rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, so pin this
 sha2 = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ futures = "0.3.21"
 futures-util = "0.3.21"
 
 hex = { version = "0.4", optional = true }
-# rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, so pin this
-hkdf = "0.11"
+hkdf = "0.12.3"
 hyper = { version = "0.14.19", optional = true, features = ["client", "h2"] }
 hyper-tls = { version = "0.5.0", optional = true }
 metrics = "0.19.0"
@@ -43,8 +42,7 @@ rand_distr = "0.4.3"
 # TODO consider using zerocopy or serde_bytes or in-house serialization
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-# rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, so pin this
-sha2 = "0.9"
+sha2 = "0.10.6"
 thiserror = "1.0"
 tokio = { version = "1.19.2", optional = true, features = ["rt", "rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ permutation = "0.4.1"
 pin-project = "1.0.12"
 rand = "0.8"
 rand_chacha = "0.3.1"
-rand_core = "0.6"
 rand_distr = "0.4.3"
 
 # TODO consider using zerocopy or serde_bytes or in-house serialization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [features]
 default = ["debug", "cli"]
-cli = ["comfy-table", "enable-serde", "metrics-tracing-context", "metrics-util", "structopt", "tracing-subscriber", "web-app"]
+cli = ["comfy-table", "clap", "enable-serde", "metrics-tracing-context", "metrics-util", "tracing-subscriber", "web-app"]
 debug = ["hex"]
 enable-serde = ["serde", "serde_json", "rust-elgamal/enable-serde"]
 web-app = ["tokio", "tokio-stream", "axum", "axum-server", "hyper", "hyper-tls", "tower", "tower-http"]
@@ -19,6 +19,7 @@ async-trait = "0.1.56"
 axum = { version = "0.5.7", optional = true, features = ["http2"] }
 axum-server = { version = "0.4.0", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
 byteorder = "1"
+clap = { version = "4.0.10", optional = true, features = ["derive"] }
 comfy-table = { version = "6.0.0", optional = true }
 # rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, not 0.10
 digest = "0.9"
@@ -45,7 +46,6 @@ serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 # rust-elgamal (via curve25519-dalek-ng) only works with digest 0.9, so pin this
 sha2 = "0.9"
-structopt = { version = "0.3", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.19.2", optional = true, features = ["rt", "rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1.9", optional = true }

--- a/benches/oneshot/arithmetic_circuit.rs
+++ b/benches/oneshot/arithmetic_circuit.rs
@@ -1,29 +1,29 @@
+use clap::Parser;
 use raw_ipa::field::{Field, Fp31};
 use raw_ipa::test_fixture::circuit;
 use std::time::Instant;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct CircuitArgs {
-    #[structopt(
+    #[arg(
         short,
         long,
         help = "width of the circuit, defines how many operations can proceed in parallel"
     )]
     pub width: u32,
 
-    #[structopt(short, long, help = "depth of the circuit")]
+    #[arg(short, long, help = "depth of the circuit")]
     pub depth: u8,
 
     /// Cargo passes the bench argument
     /// https://doc.rust-lang.org/cargo/commands/cargo-bench.html
-    #[structopt(short, long, help = "ignored")]
+    #[arg(short, long, help = "ignored")]
     pub bench: bool,
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 3)]
 pub async fn main() {
-    let args = CircuitArgs::from_args();
+    let args = CircuitArgs::parse();
 
     {
         let field_size = <Fp31 as Field>::Integer::BITS;

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -1,33 +1,32 @@
 use std::error::Error;
 
+use clap::Parser;
 use hyper::http::uri::Scheme;
 use raw_ipa::cli::net::{bind_mpc_helper_server, BindTarget};
 use raw_ipa::cli::Verbosity;
 use std::net::SocketAddr;
 use std::panic;
-
-use structopt::StructOpt;
 use tracing::info;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "mpc-helper", about = "CLI to start an MPC helper endpoint")]
+#[derive(Debug, Parser)]
+#[clap(name = "mpc-helper", about = "CLI to start an MPC helper endpoint")]
 struct Args {
     /// Configure logging.
-    #[structopt(flatten)]
+    #[clap(flatten)]
     logging: Verbosity,
 
     /// Port to listen. If not specified, will ask Kernel to assign the port
-    #[structopt(short = "p", long = "port")]
+    #[arg(short, long)]
     port: Option<u16>,
 
     /// Indicates whether to start HTTP or HTTPS endpoint
-    #[structopt(short = "-s", long = "scheme", default_value = "http")]
+    #[arg(short, long, default_value = "http")]
     scheme: Scheme,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let args = Args::from_args();
+    let args = Args::parse();
     let _handle = args.logging.setup_logging();
 
     // decide what protocol we're going to use here

--- a/src/bin/ipa_bench/cmd.rs
+++ b/src/bin/ipa_bench/cmd.rs
@@ -2,32 +2,26 @@ use crate::sample::Sample;
 
 use super::gen_events::generate_events;
 
+use clap::Parser;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use raw_ipa::cli::Verbosity;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::{io, process};
-use structopt::StructOpt;
 use tracing::{debug, error, info};
 
 const DEFAULT_EVENT_GEN_COUNT: u32 = 100_000;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct CommonArgs {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub logging: Verbosity,
 
-    #[structopt(
-        short,
-        long,
-        global = true,
-        help = "Write the result to the file.",
-        parse(from_os_str)
-    )]
+    #[arg(short, long, global = true, help = "Write the result to the file.")]
     output_file: Option<PathBuf>,
 
-    #[structopt(long, global = true, help = "Overwrite the specified output file.")]
+    #[arg(long, global = true, help = "Overwrite the specified output file.")]
     overwrite: bool,
 }
 
@@ -52,22 +46,22 @@ impl CommonArgs {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "ipa_bench", about = "Synthetic data test harness for IPA")]
+#[derive(Debug, Parser)]
+#[clap(name = "ipa_bench", about = "Synthetic data test harness for IPA")]
 pub struct Args {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub common: CommonArgs,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: Command,
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "command")]
+#[derive(Debug, Parser)]
+#[clap(name = "command")]
 pub enum Command {
-    #[structopt(about = "Generate synthetic events.")]
+    #[command(about = "Generate synthetic events.")]
     GenEvents {
-        #[structopt(
+        #[arg(
             short,
             long,
             default_value = "1",
@@ -75,14 +69,14 @@ pub enum Command {
         )]
         scale_factor: u32,
 
-        #[structopt(
+        #[arg(
             short,
             long,
             help = "Random generator seed. Setting the seed allows reproduction of the synthetic data exactly."
         )]
         random_seed: Option<u64>,
 
-        #[structopt(
+        #[arg(
             short,
             long,
             default_value = "0",
@@ -90,11 +84,10 @@ pub enum Command {
         )]
         epoch: u8,
 
-        #[structopt(
+        #[arg(
             short,
             long,
-            help = "Configuration file containing distributions data.",
-            parse(from_os_str)
+            help = "Configuration file containing distributions data."
         )]
         config_file: PathBuf,
     },

--- a/src/bin/ipa_bench/gen_events.rs
+++ b/src/bin/ipa_bench/gen_events.rs
@@ -2,9 +2,9 @@ use crate::models::{Epoch, Event, EventTimestamp, GenericReport, MatchKey, Numbe
 
 use super::sample::Sample;
 use byteorder::WriteBytesExt;
+use rand::distributions::Bernoulli;
+use rand::distributions::Distribution;
 use rand::{CryptoRng, Rng, RngCore};
-use rand_distr::num_traits::ToPrimitive;
-use rand_distr::{Bernoulli, Distribution};
 use std::io;
 use tracing::{debug, info, trace};
 
@@ -58,8 +58,8 @@ pub fn generate_events<R: RngCore + CryptoRng, W: io::Write>(
 
             let events = gen_reports(impressions, conversions, epoch, ad_id, sample, rng);
 
-            total_impressions += impressions.to_u32().unwrap();
-            total_conversions += conversions.to_u32().unwrap();
+            total_impressions += u32::from(impressions);
+            total_conversions += u32::from(conversions);
 
             for e in events {
                 out.write_u8(RECORD_SEPARATOR).unwrap();

--- a/src/bin/ipa_bench/ipa_bench.rs
+++ b/src/bin/ipa_bench/ipa_bench.rs
@@ -4,10 +4,10 @@ mod gen_events;
 mod models;
 mod sample;
 
-use structopt::StructOpt;
+use clap::Parser;
 
 fn main() {
-    let args = cmd::Args::from_args();
+    let args = cmd::Args::parse();
     let _handle = args.common.logging.setup_logging();
     args.cmd.dispatch(&args.common);
 }

--- a/src/bin/ipa_bench/sample.rs
+++ b/src/bin/ipa_bench/sample.rs
@@ -101,6 +101,7 @@ impl<'a> Sample<'a> {
             .index
             .clone();
         let diff = (rng.gen_range(r) * 60.0 * 60.0).floor();
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         Duration::from_secs(diff as u64)
     }
 
@@ -113,7 +114,7 @@ impl<'a> Sample<'a> {
 
         // Since [diff] is a range of days, randomly choose hours and seconds for the given range.
         // E.g. return [1..3) days + y hours + z seconds
-        Duration::new(diff as u64 * 24 * 60 * 60, 0)
+        Duration::new(u64::from(diff) * 24 * 60 * 60, 0)
             + Duration::new(rng.gen_range(0..23) * 60 * 60, 0)
             + Duration::new(rng.gen_range(0..59) * 60, 0)
             + Duration::new(rng.gen_range(0..59), 0)

--- a/src/bin/ipa_bench/sample.rs
+++ b/src/bin/ipa_bench/sample.rs
@@ -1,6 +1,6 @@
+use rand::distributions::Distribution;
 use rand::distributions::WeightedIndex;
 use rand::{CryptoRng, Rng, RngCore};
-use rand_distr::{num_traits::ToPrimitive, Distribution};
 use std::time::Duration;
 
 use crate::config::Config;
@@ -100,8 +100,8 @@ impl<'a> Sample<'a> {
         let r = self.config.impression_impression_duration[self.frequency_cap_distr.sample(rng)]
             .index
             .clone();
-        let diff = rng.gen_range(r);
-        Duration::new((diff * 60.0 * 60.0).floor().to_u64().unwrap(), 0)
+        let diff = (rng.gen_range(r) * 60.0 * 60.0).floor();
+        Duration::from_secs(diff as u64)
     }
 
     pub fn conversions_time_diff<R: RngCore + CryptoRng>(&self, rng: &mut R) -> Duration {
@@ -113,7 +113,7 @@ impl<'a> Sample<'a> {
 
         // Since [diff] is a range of days, randomly choose hours and seconds for the given range.
         // E.g. return [1..3) days + y hours + z seconds
-        Duration::new(diff.to_u64().unwrap() * 24 * 60 * 60, 0)
+        Duration::new(diff as u64 * 24 * 60 * 60, 0)
             + Duration::new(rng.gen_range(0..23) * 60 * 60, 0)
             + Duration::new(rng.gen_range(0..59) * 60, 0)
             + Duration::new(rng.gen_range(0..59), 0)

--- a/src/bin/test_mpc.rs
+++ b/src/bin/test_mpc.rs
@@ -1,26 +1,26 @@
+use clap::Parser;
 use raw_ipa::cli::{
     net::{Client, Command, MpcHandle},
     Verbosity,
 };
 use std::error::Error;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "mpc-client",
     about = "CLI to execute test scenarios on IPA MPC helpers"
 )]
 struct Args {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     logging: Verbosity,
 
-    #[structopt(short, long)]
+    #[arg(short, long)]
     uri: String,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let args = Args::from_args();
+    let args = Args::parse();
     let _handle = args.logging.setup_logging();
 
     // TODO: Start MPC helpers and discover

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -31,7 +31,7 @@ pub struct CounterDetails {
 /// X1 and X2 cannot be greater than X, but these values may overlap, i.e. X1 + X2 >= X
 pub struct Metrics {
     counters: HashMap<KeyName, CounterDetails>,
-    metric_description: HashMap<KeyName, &'static str>,
+    metric_description: HashMap<KeyName, SharedString>,
 }
 
 impl CounterDetails {
@@ -107,7 +107,9 @@ impl Metrics {
 
             metrics_table.add_row(vec![
                 key_name.as_str(),
-                self.metric_description.get(key_name).unwrap_or(&""),
+                self.metric_description
+                    .get(key_name)
+                    .unwrap_or(&SharedString::from("")),
                 counter_stats.total_value.to_string().as_str(),
                 dim_cell_content.as_str(),
             ]);

--- a/src/cli/verbosity.rs
+++ b/src/cli/verbosity.rs
@@ -1,22 +1,20 @@
-use metrics_tracing_context::MetricsLayer;
-
-use std::io::stderr;
-
 use crate::cli::install_collector;
 use crate::cli::metric_collector::CollectorHandle;
-use structopt::StructOpt;
+use clap::Parser;
+use metrics_tracing_context::MetricsLayer;
+use std::io::stderr;
 use tracing::{info, metadata::LevelFilter, Level};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Verbosity {
     /// Silence all output
-    #[structopt(short = "q", long = "quiet", global = true)]
+    #[clap(short, long, global = true)]
     quiet: bool,
 
     /// Verbose mode (-v, -vv, -vvv, etc)
-    #[structopt(short = "v", long = "verbose", global = true, parse(from_occurrences))]
-    verbose: usize,
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
 }
 
 pub struct LoggingHandle {

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -226,8 +226,7 @@ pub mod tests {
     use crate::helpers::mock::TestHelperGateway;
     use crate::protocol::context::ProtocolContext;
     use rand::rngs::mock::StepRng;
-
-    use rand_core::RngCore;
+    use rand::RngCore;
 
     use futures_util::future::join_all;
     use tokio::try_join;

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -42,13 +42,13 @@ mod tests {
     #[test]
     fn apply_shares() {
         let mut values = ["A", "B", "C", "D"];
-        let mut indices = Permutation::from_vec([2, 3, 1, 0]);
+        let mut indices = Permutation::oneline([2, 3, 1, 0]).inverse();
         let expected_output_apply = ["C", "D", "B", "A"];
         apply(&mut indices, &mut values);
         assert_eq!(values, expected_output_apply);
 
         let mut values = ["A", "B", "C", "D"];
-        let mut indices = Permutation::from_vec([2, 3, 1, 0]);
+        let mut indices = Permutation::oneline([2, 3, 1, 0]).inverse();
         let expected_output_apply_inv = ["D", "C", "A", "B"];
         apply_inv(&mut indices, &mut values);
         assert_eq!(values, expected_output_apply_inv);

--- a/src/secret_sharing/shamir.rs
+++ b/src/secret_sharing/shamir.rs
@@ -5,7 +5,7 @@
 //!
 use crate::field::{Field, Fp31};
 use rand::Rng;
-use rand_core::RngCore;
+use rand::RngCore;
 use std::iter::repeat_with;
 use std::num::NonZeroU8;
 use std::ops::Add;
@@ -212,7 +212,7 @@ mod tests {
     use proptest::prelude::*;
     use rand::rngs::StdRng;
     use rand::thread_rng;
-    use rand_core::SeedableRng;
+    use rand::SeedableRng;
     use std::cmp::max;
     use std::num::NonZeroU8;
 

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -1,7 +1,7 @@
 use crate::field::Field;
 use crate::secret_sharing::Replicated;
 use rand::Rng;
-use rand_core::RngCore;
+use rand::RngCore;
 
 /// Shares `input` into 3 replicated secret shares using the provided `rng` implementation
 pub fn share<F: Field, R: RngCore>(input: F, rng: &mut R) -> [Replicated<F>; 3] {


### PR DESCRIPTION
* Upgrade to clap v4 from structopt. Structopt is in maintenance mode and has been ported to clap_derive. 
* Bump the deps
* Bump Rust compiler to 1.64
* Remove unused dependencies