### PR TITLE
Mod conversion [Part 1]

### DIFF
--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -1,6 +1,7 @@
 use crate::helpers::fabric::Network;
 use crate::helpers::messaging::Gateway;
 use crate::helpers::prss::{Participant, SpaceIndex};
+use crate::helpers::Identity;
 
 use super::{securemul::SecureMul, sort::reveal::Reveal, RecordId, Step};
 
@@ -12,13 +13,15 @@ use super::{securemul::SecureMul, sort::reveal::Reveal, RecordId, Step};
 pub struct ProtocolContext<'a, S: SpaceIndex, F> {
     pub participant: &'a Participant<S>,
     pub gateway: &'a Gateway<S, F>,
+    pub identity: Identity,
 }
 
 impl<'a, S: Step + SpaceIndex, F: Network<S>> ProtocolContext<'a, S, F> {
-    pub fn new(participant: &'a Participant<S>, gateway: &'a Gateway<S, F>) -> Self {
+    pub fn new(participant: &'a Participant<S>, gateway: &'a Gateway<S, F>, identity: Identity) -> Self {
         Self {
             participant,
             gateway,
+            identity,
         }
     }
 

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -17,7 +17,11 @@ pub struct ProtocolContext<'a, S: SpaceIndex, F> {
 }
 
 impl<'a, S: Step + SpaceIndex, F: Network<S>> ProtocolContext<'a, S, F> {
-    pub fn new(participant: &'a Participant<S>, gateway: &'a Gateway<S, F>, identity: Identity) -> Self {
+    pub fn new(
+        participant: &'a Participant<S>,
+        gateway: &'a Gateway<S, F>,
+        identity: Identity,
+    ) -> Self {
         Self {
             participant,
             gateway,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,4 +1,5 @@
 pub mod context;
+mod modulus_conversion;
 mod securemul;
 pub mod sort;
 
@@ -32,7 +33,7 @@ pub trait Step: Copy + Clone + Debug + Eq + Hash + Send + 'static {}
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum IPAProtocolStep {
     /// Convert from XOR shares to Replicated shares
-    ConvertShares,
+    ConvertShares(ModulusConversionStep),
     /// Sort shares by the match key
     Sort(SortStep),
 }
@@ -41,8 +42,8 @@ impl Debug for IPAProtocolStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "IPA/")?;
         match self {
-            IPAProtocolStep::ConvertShares => {
-                write!(f, "ConvertShares")
+            IPAProtocolStep::ConvertShares(modulus_conversion_step) => {
+                write!(f, "ConvertShares/{:?}", modulus_conversion_step)
             }
             IPAProtocolStep::Sort(sort_step) => {
                 write!(f, "Sort/{:?}", sort_step)
@@ -58,7 +59,7 @@ impl SpaceIndex for IPAProtocolStep {
 
     fn as_usize(&self) -> usize {
         match self {
-            IPAProtocolStep::ConvertShares => 0,
+            IPAProtocolStep::ConvertShares(_) => 0,
             IPAProtocolStep::Sort(_) => 1,
         }
     }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -33,7 +33,7 @@ pub trait Step: Copy + Clone + Debug + Eq + Hash + Send + 'static {}
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum IPAProtocolStep {
     /// Convert from XOR shares to Replicated shares
-    ConvertShares(ModulusConversionStep),
+    ConvertShares,
     /// Sort shares by the match key
     Sort(SortStep),
 }
@@ -42,8 +42,8 @@ impl Debug for IPAProtocolStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "IPA/")?;
         match self {
-            IPAProtocolStep::ConvertShares(modulus_conversion_step) => {
-                write!(f, "ConvertShares/{:?}", modulus_conversion_step)
+            IPAProtocolStep::ConvertShares => {
+                write!(f, "ConvertShares")
             }
             IPAProtocolStep::Sort(sort_step) => {
                 write!(f, "Sort/{:?}", sort_step)
@@ -59,7 +59,7 @@ impl SpaceIndex for IPAProtocolStep {
 
     fn as_usize(&self) -> usize {
         match self {
-            IPAProtocolStep::ConvertShares(_) => 0,
+            IPAProtocolStep::ConvertShares => 0,
             IPAProtocolStep::Sort(_) => 1,
         }
     }

--- a/src/protocol/modulus_conversion/gen_random.rs
+++ b/src/protocol/modulus_conversion/gen_random.rs
@@ -135,8 +135,8 @@ mod tests {
     pub async fn gen_random() {
         let mut rng = rand::thread_rng();
 
-        for _ in 0..10 {
-            let record_id = RecordId::from(1);
+        for i in 0..40 {
+            let record_id = RecordId::from(i);
 
             let world: TestWorld<ModulusConversionTestStep> = make_world(QueryId);
             let context = make_contexts(&world);

--- a/src/protocol/modulus_conversion/gen_random.rs
+++ b/src/protocol/modulus_conversion/gen_random.rs
@@ -12,7 +12,6 @@ use crate::{
 
 use serde::{Deserialize, Serialize};
 
-/// A message sent by each helper when they've reshared their own shares
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
 pub struct ReplicatedBinary(bool, bool);
 
@@ -30,7 +29,6 @@ pub enum ModulusConversionStep {
     Xor2,
 }
 
-/// GenRandom(i, \[x\])
 #[derive(Debug)]
 pub struct GenRandom {
     input: ReplicatedBinary,
@@ -115,9 +113,7 @@ mod tests {
         internal_step: ModulusConversionStep,
     }
 
-    impl Step for ModulusConversionTestStep {
-        // TODO
-    }
+    impl Step for ModulusConversionTestStep {}
 
     impl SpaceIndex for ModulusConversionTestStep {
         const MAX: usize = 512;
@@ -142,11 +138,11 @@ mod tests {
             let context = make_contexts(&world);
 
             let step1 = ModulusConversionTestStep {
-                bit_number: 0,
+                bit_number: i,
                 internal_step: ModulusConversionStep::Xor1,
             };
             let step2 = ModulusConversionTestStep {
-                bit_number: 0,
+                bit_number: i,
                 internal_step: ModulusConversionStep::Xor2,
             };
 

--- a/src/protocol/modulus_conversion/gen_random.rs
+++ b/src/protocol/modulus_conversion/gen_random.rs
@@ -1,11 +1,7 @@
 use crate::{
     error::BoxError,
     field::Field,
-    helpers::{
-        fabric::Network,
-        prss::SpaceIndex,
-        Identity,
-    },
+    helpers::{fabric::Network, prss::SpaceIndex, Identity},
     protocol::{context::ProtocolContext, RecordId, Step},
     secret_sharing::Replicated,
 };
@@ -140,9 +136,9 @@ mod tests {
         },
         test_fixture::{make_contexts, make_world, validate_and_reconstruct, TestWorld},
     };
-    use tokio::try_join;
     use futures::future::try_join_all;
     use proptest::prelude::Rng;
+    use tokio::try_join;
 
     #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
     struct ModulusConversionTestStep {

--- a/src/protocol/modulus_conversion/gen_random.rs
+++ b/src/protocol/modulus_conversion/gen_random.rs
@@ -1,0 +1,148 @@
+use crate::{
+    error::BoxError,
+    field::Field,
+    helpers::{
+        mesh::{Gateway, Mesh},
+        Identity,
+    },
+    protocol::{context::ProtocolContext, IPAProtocolStep, ModulusConversionStep, RecordId},
+    secret_sharing::Replicated,
+};
+use serde::{Deserialize, Serialize};
+
+/// A message sent by each helper when they've reshared their own shares
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct ReplicatedBinary {
+    left: bool,
+    right: bool,
+}
+/// GenRandom(i, \[x\])
+#[derive(Debug)]
+pub struct GenRandom<F> {
+    input: ReplicatedBinary,
+}
+
+impl<F: Field> GenRandom<F> {
+    #[allow(dead_code)]
+    pub fn new(input: ReplicatedBinary) -> Self {
+        Self { input }
+    }
+
+    fn local_secret_share(
+        input: ReplicatedBinary,
+        channel_identity: Identity,
+    ) -> (Replicated<F>, Replicated<F>, Replicated<F>)
+    where
+        F: Field,
+    {
+        match channel_identity() {
+            Identity::H1 => (
+                Replicated::new(F::from(input.left), F::ZERO),
+                Replicated::new(F::ZERO, F::from(input.right)),
+                Replicated::new(F::ZERO, F::ZERO),
+            ),
+            Identity::H2 => (
+                Replicated::new(F::ZERO, F::ZERO),
+                Replicated::new(F::from(input.left), F::ZERO),
+                Replicated::new(F::ZERO, F::from(input.right)),
+            ),
+            Identity::H3 => (
+                Replicated::new(F::ZERO, F::from(input.right)),
+                Replicated::new(F::ZERO, F::ZERO),
+                Replicated::new(F::from(input.left), F::ZERO),
+            ),
+        }
+    }
+
+    async fn xor<M: Mesh, G: Gateway<M, IPAProtocolStep>>(
+        a: Replicated<F>,
+        b: Replicated<F>,
+        ctx: &ProtocolContext<'_, G, IPAProtocolStep>,
+        step: IPAProtocolStep,
+        record_id: RecordId,
+    ) -> Result<Replicated<F>, BoxError> {
+        let result = ctx.multiply(record_id, step).await.execute(a, b).await?;
+
+        a + b - (result * 2)
+    }
+
+    #[allow(dead_code)]
+    pub async fn execute<M: Mesh, G: Gateway<M, IPAProtocolStep>>(
+        &self,
+        ctx: &ProtocolContext<'_, G, IPAProtocolStep>,
+        record_id: RecordId,
+    ) -> Result<Vec<Replicated<F>>, BoxError>
+    where
+        F: Field,
+    {
+        let mut channel = ctx.gateway.get_channel(IPAProtocolStep::ConvertShares(
+            ModulusConversionStep::Share0XORShare1,
+        ));
+        let (sh0, sh1, sh2) = Self::local_secret_share(self.input, channel.identity());
+
+        let sh0_xor_sh1 = Self::xor(
+            sh0,
+            sh1,
+            ctx,
+            IPAProtocolStep::ConvertShares(ModulusConversionStep::Share0XORShare1),
+            record_id,
+        )?;
+        Self::xor(
+            sh0_xor_sh1,
+            sh2,
+            ctx,
+            IPAProtocolStep::ConvertShares(ModulusConversionStep::ResultXORShare2),
+            record_id,
+        )?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::Rng;
+    use rand::rngs::mock::StepRng;
+    use tokio::try_join;
+
+    use crate::{
+        field::Fp31,
+        helpers::Identity,
+        test_fixture::{
+            make_contexts, make_world, share, validate_and_reconstruct, TestStep, TestWorld,
+        },
+    };
+
+    #[tokio::test]
+    pub async fn gen_random() {
+        let mut rand = StepRng::new(100, 1);
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..10 {
+            let secret = rng.gen::<u128>();
+
+            let record_id = RecordId::from(1);
+
+            let world: TestWorld<TestStep> = make_world(QueryId);
+            let context = make_contexts(&world);
+
+            let step = TestStep::Reshare(1);
+
+            let b0 = rng.gen() > 0.5;
+            let b1 = rng.gen() > 0.5;
+            let b2 = rng.gen() > 0.5;
+
+            input = (b0 ^ b1) ^ b2;
+
+            let gen_random0 = GenRandom::new(ReplicatedBinary { b0, b1 });
+            let gen_random1 = GenRandom::new(ReplicatedBinary { b1, b2 });
+            let gen_random2 = GenRandom::new(ReplicatedBinary { b2, b0 });
+
+            let h0_future = gen_random0.execute(&context[0], record_id, step);
+            let h1_future = gen_random1.execute(&context[1], record_id, step);
+            let h2_future = gen_random2.execute(&context[2], record_id, step);
+
+            let f = try_join!(h0_future, h1_future, h2_future).unwrap();
+            let output_share = validate_and_reconstruct(f);
+            assert_eq!(output_share, input);
+        }
+    }
+}

--- a/src/protocol/modulus_conversion/gen_random.rs
+++ b/src/protocol/modulus_conversion/gen_random.rs
@@ -43,25 +43,22 @@ impl GenRandom {
     fn local_secret_share<F: Field>(
         input: ReplicatedBinary,
         channel_identity: Identity,
-    ) -> (Replicated<F>, Replicated<F>, Replicated<F>)
-    where
-        F: Field,
-    {
+    ) -> (Replicated<F>, Replicated<F>, Replicated<F>) {
         match channel_identity {
             Identity::H1 => (
-                Replicated::new(F::from(input.0 as u128), F::ZERO),
-                Replicated::new(F::ZERO, F::from(input.1 as u128)),
+                Replicated::new(F::from(u128::from(input.0)), F::ZERO),
+                Replicated::new(F::ZERO, F::from(u128::from(input.1))),
                 Replicated::new(F::ZERO, F::ZERO),
             ),
             Identity::H2 => (
                 Replicated::new(F::ZERO, F::ZERO),
-                Replicated::new(F::from(input.0 as u128), F::ZERO),
-                Replicated::new(F::ZERO, F::from(input.1 as u128)),
+                Replicated::new(F::from(u128::from(input.0)), F::ZERO),
+                Replicated::new(F::ZERO, F::from(u128::from(input.1))),
             ),
             Identity::H3 => (
-                Replicated::new(F::ZERO, F::from(input.1 as u128)),
+                Replicated::new(F::ZERO, F::from(u128::from(input.1))),
                 Replicated::new(F::ZERO, F::ZERO),
-                Replicated::new(F::from(input.0 as u128), F::ZERO),
+                Replicated::new(F::from(u128::from(input.0)), F::ZERO),
             ),
         }
     }
@@ -89,7 +86,7 @@ impl GenRandom {
         let (sh0, sh1, sh2) = Self::local_secret_share(self.input, ctx.identity);
 
         let sh0_xor_sh1 = Self::xor(sh0, sh1, ctx, step1, record_id).await?;
-        Ok(Self::xor(sh0_xor_sh1, sh2, ctx, step2, record_id).await?)
+        Self::xor(sh0_xor_sh1, sh2, ctx, step2, record_id).await
     }
 }
 
@@ -131,8 +128,8 @@ mod tests {
     pub async fn gen_random() {
         let mut rng = rand::thread_rng();
 
-        for i in 0..40 {
-            let record_id = RecordId::from(i);
+        for i in 0_u8..40 {
+            let record_id = RecordId::from(u32::from(i));
 
             let world: TestWorld<ModulusConversionTestStep> = make_world(QueryId);
             let context = make_contexts(&world);
@@ -150,7 +147,7 @@ mod tests {
             let b1 = rng.gen::<u8>() >= 128;
             let b2 = rng.gen::<u8>() >= 128;
 
-            let input = ((b0 ^ b1) ^ b2) as u128;
+            let input = u128::from((b0 ^ b1) ^ b2);
 
             let gen_random0 = GenRandom::new(ReplicatedBinary::new(b0, b1));
             let gen_random1 = GenRandom::new(ReplicatedBinary::new(b1, b2));

--- a/src/protocol/modulus_conversion/gen_random.rs
+++ b/src/protocol/modulus_conversion/gen_random.rs
@@ -26,28 +26,28 @@ pub enum ModulusConversionStep {
 }
 
 ///
-/// This file is an implementation of Algorithm D.3 from https://eprint.iacr.org/2018/387.pdf
+/// This file is an implementation of Algorithm D.3 from <https://eprint.iacr.org/2018/387.pdf>
 /// "Efficient generation of a pair of random shares for small number of parties"
 ///
-/// In order to convert from a 3-party secret sharing in Z_2, to a 3-party replicated
-/// secret sharing in Z_p (where p > 2), we need to generate two secret sharings of
-/// a random value 'r' ∈ {0, 1}, where none of the helper parties know the value of 'r'.
+/// In order to convert from a 3-party secret sharing in `Z_2`, to a 3-party replicated
+/// secret sharing in `Z_p` (where p > 2), we need to generate two secret sharings of
+/// a random value `r` ∈ {0, 1}, where none of the helper parties know the value of `r`.
 /// With Psuedo-random secret-sharing (PRSS), we can generate a 3-party replicated
 /// secret-sharing of unknown value 'r' without any interaction between the helpers.
 /// We just generate 3 random binary inputs, where each helper is aware of just two.
 ///
-/// This 'GenRandom' protocol takes as input such a 3-way random binary replicated secret-sharing,
+/// This `GenRandom` protocol takes as input such a 3-way random binary replicated secret-sharing,
 /// and produces a 3-party replicated secret-sharing of the same value in a target field
 /// of the caller's choosing.
 /// Example:
-/// For input binary sharing: (0, 1, 1) -> which is a sharing of 0 in Z_2
-/// sample output in Z_31 could be: (22, 19, 21) -> also a sharing of 0 in Z_31
+/// For input binary sharing: (0, 1, 1) -> which is a sharing of 0 in `Z_2`
+/// sample output in `Z_31` could be: (22, 19, 21) -> also a sharing of 0 in `Z_31`
 /// This transformation is simple:
 /// The original can be conceived of as r = b0 ⊕ b1 ⊕ b2
-/// Each of the 3 bits can be trivially converted into a 3-way secret sharing in Z_p
-/// So if the second bit is a '1', we can make a 3-way secret sharing of '1' in Z_p
+/// Each of the 3 bits can be trivially converted into a 3-way secret sharing in `Z_p`
+/// So if the second bit is a '1', we can make a 3-way secret sharing of '1' in `Z_p`
 /// as (0, 1, 0).
-/// Now we simply need to XOR these three sharings together in Z_p. This is easy because
+/// Now we simply need to XOR these three sharings together in `Z_p`. This is easy because
 /// we know the secret-shared values are all either 0, or 1. As such, the XOR operation
 /// is equivalent to fn xor(a, b) { a + b - 2*a*b }
 #[derive(Debug)]
@@ -63,7 +63,7 @@ impl GenRandom {
 
     ///
     /// Internal use only.
-    /// This is an implementation of "Algorithm 3" from https://eprint.iacr.org/2018/387.pdf
+    /// This is an implementation of "Algorithm 3" from <https://eprint.iacr.org/2018/387.pdf>
     ///
     fn local_secret_share<F: Field>(
         input: ReplicatedBinary,
@@ -108,7 +108,7 @@ impl GenRandom {
 
     ///
     /// This will convert the input (a random, replicated binary secret sharing
-    /// of unknown number 'r') into a random secret sharing of the same value in Z_p
+    /// of unknown number 'r') into a random secret sharing of the same value in `Z_p`
     /// where the caller can select the output Field.
     #[allow(dead_code)]
     pub async fn execute<F: Field, S: Step + SpaceIndex, N: Network<S>>(
@@ -170,10 +170,9 @@ mod tests {
         let ctx1 = &context[1];
         let ctx2 = &context[2];
 
-        let counting: Vec<u128> = (0..40).collect();
         let mut bools: Vec<u128> = Vec::with_capacity(40);
 
-        let inputs = counting.into_iter().map(|_| {
+        let inputs = (0..40).into_iter().map(|_i| {
             let b0 = rng.gen::<bool>();
             let b1 = rng.gen::<bool>();
             let b2 = rng.gen::<bool>();
@@ -190,13 +189,15 @@ mod tests {
             .into_iter()
             .enumerate()
             .map(|(index, (gr0, gr1, gr2))| async move {
-                let record_id = RecordId::from(index as u32);
+                let index_bytes: [u8; 8] = index.to_le_bytes();
+                let i = index_bytes[0];
+                let record_id = RecordId::from(0_u32);
                 let step1 = ModulusConversionTestStep {
-                    bit_number: 0_u8,
+                    bit_number: i,
                     internal_step: ModulusConversionStep::Xor1,
                 };
                 let step2 = ModulusConversionTestStep {
-                    bit_number: 0_u8,
+                    bit_number: i,
                     internal_step: ModulusConversionStep::Xor2,
                 };
 

--- a/src/protocol/modulus_conversion/mod.rs
+++ b/src/protocol/modulus_conversion/mod.rs
@@ -1,0 +1,1 @@
+mod gen_random;

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -157,6 +157,7 @@ pub mod stream {
     #[cfg(test)]
     mod tests {
         use crate::field::Fp31;
+        use crate::helpers::Identity;
         use crate::protocol::context::ProtocolContext;
         use crate::protocol::securemul::stream::secure_multiply;
         use crate::protocol::QueryId;
@@ -196,9 +197,10 @@ pub mod stream {
                 .into_iter()
                 .zip(world.participants)
                 .zip(world.gateways)
-                .map(|((input, prss), gateway)| {
+                .zip([Identity::H1, Identity::H2, Identity::H3])
+                .map(|(((input, prss), gateway), identity)| {
                     tokio::spawn(async move {
-                        let ctx = ProtocolContext::new(&prss, &gateway);
+                        let ctx = ProtocolContext::new(&prss, &gateway, identity);
                         let mut stream = secure_multiply(input, &ctx, start_index);
 
                         // compute a*b

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -5,6 +5,7 @@ mod sharing;
 mod world;
 
 use crate::field::Fp31;
+use crate::helpers::Identity;
 use crate::helpers::prss::{Participant, ParticipantSetup, SpaceIndex};
 use crate::protocol::context::ProtocolContext;
 use crate::protocol::Step;
@@ -30,7 +31,10 @@ pub fn make_contexts<S: Step + SpaceIndex>(
         .gateways
         .iter()
         .zip(&test_world.participants)
-        .map(|(gateway, participant)| ProtocolContext::new(participant, gateway))
+        .zip([Identity::H1, Identity::H2, Identity::H3])
+        .map(|((gateway, participant), identity)| {
+            ProtocolContext::new(participant, gateway, identity)
+        })
         .collect::<Vec<_>>()
         .try_into()
         .unwrap()

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -5,8 +5,8 @@ mod sharing;
 mod world;
 
 use crate::field::Fp31;
-use crate::helpers::Identity;
 use crate::helpers::prss::{Participant, ParticipantSetup, SpaceIndex};
+use crate::helpers::Identity;
 use crate::protocol::context::ProtocolContext;
 use crate::protocol::Step;
 use crate::secret_sharing::Replicated;


### PR DESCRIPTION
To convert from XOR secret shares of match keys, the lists of replicated secret sharings of each bit in Z_p, we will need to generate pairs of secret sharings of "r", a random number not known to any of the helpers.

This diff introduces code that given a binary replicated secret sharing of "r" (which can be locally generated using PRSS), converts that into a replicated secret sharing of the same value in Z_p. This is the main work involved in the modulus conversion.

There are additional optimisations to add later. 