### PR TITLE
Fixing test and adding asserts

### DIFF
--- a/src/protocol/sort/reshare.rs
+++ b/src/protocol/sort/reshare.rs
@@ -114,7 +114,7 @@ mod tests {
     pub async fn reshare() {
         let mut rand = StepRng::new(100, 1);
         let mut rng = rand::thread_rng();
-
+        let mut new_reshares_atleast_once = false;
         for _ in 0..10 {
             let secret = rng.gen::<u128>();
 
@@ -139,9 +139,11 @@ mod tests {
             let output_share = validate_and_reconstruct(f);
             assert_eq!(output_share, input);
 
-            assert_ne!(share[0], f.0);
-            assert_ne!(share[1], f.1);
-            assert_ne!(share[2], f.2);
+            if share[0] != f.0 && share[1] != f.1 && share[2] != f.2 {
+                new_reshares_atleast_once = true;
+                break;
+            }
         }
+        assert!(new_reshares_atleast_once);
     }
 }

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -69,15 +69,15 @@ impl Debug for TestStep {
 impl Step for TestStep {}
 
 impl SpaceIndex for TestStep {
-    const MAX: usize = 5;
-
+    const MAX: usize = u8::BITS as usize * 3 + ShuffleStep::MAX + 1;
     fn as_usize(&self) -> usize {
+        let u8_size = u8::BITS as usize;
         match self {
-            TestStep::Mul1(_) => 0,
-            TestStep::Mul2 => 1,
-            TestStep::Reshare(_) => 2,
-            TestStep::Reveal(_) => 3,
-            TestStep::Shuffle(_) => 4,
+            TestStep::Mul1(s) => *s as usize,
+            TestStep::Mul2 => u8_size,
+            TestStep::Reshare(s) => u8_size + 1 + *s as usize,
+            TestStep::Reveal(s) => u8_size * 2 + 1 + *s as usize,
+            TestStep::Shuffle(s) => u8_size * 3 + 1 + s.as_usize(),
         }
     }
 }


### PR DESCRIPTION
1. Fixing reshare test to avoid flaky behavior
2. Adding a test to validate a new space is generated for each step
3. Added assert in shuffle to ensure steps do not share prss.