### PR TITLE
Implemented modulus conversion

### DIFF
--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -11,7 +11,7 @@ use crate::{
 /// Context used by each helper to perform computation. Currently they need access to shared
 /// randomness generator (see `Participant`) and communication trait to send messages to each other.
 #[allow(clippy::module_name_repetitions)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ProtocolContext<'a, N> {
     role: Identity,
     step: UniqueStepId,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -2,6 +2,7 @@ pub mod context;
 mod modulus_conversion;
 pub mod prss;
 mod reveal;
+mod reveal_additive_binary;
 mod securemul;
 pub mod sort;
 
@@ -168,5 +169,11 @@ impl From<u32> for RecordId {
 impl From<RecordId> for u128 {
     fn from(r: RecordId) -> Self {
         r.0.into()
+    }
+}
+
+impl From<RecordId> for u32 {
+    fn from(r: RecordId) -> Self {
+        r.0
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -171,9 +171,3 @@ impl From<RecordId> for u128 {
         r.0.into()
     }
 }
-
-impl From<RecordId> for u32 {
-    fn from(r: RecordId) -> Self {
-        r.0
-    }
-}

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -1,0 +1,180 @@
+use crate::{
+    error::BoxError,
+    field::Field,
+    helpers::{fabric::Network, prss::SpaceIndex},
+    protocol::{
+        context::ProtocolContext,
+        modulus_conversion::gen_random::{GenRandom, ReplicatedBinary},
+        reveal_additive_binary::RevealAdditiveBinary,
+        RecordId, Step,
+    },
+    secret_sharing::Replicated,
+};
+use futures::future::try_join_all;
+
+pub struct XorShares {
+    num_bits: u8,
+    packed_bits: u64,
+}
+
+pub struct ConvertShares {
+    input: XorShares,
+}
+
+///
+/// This is an implementation of
+/// Protocol 5.2 Modulus-conversion protocol from `Z_2^u` to `Z_p`
+/// from the paper <https://eprint.iacr.org/2018/387.pdf>
+///
+/// It works by generating two secret-sharings of a random number `r`,
+/// one in `Z_2`, the other in `Z_p`. The sharing in `Z_2` is subtracted
+/// from the input and the result is revealed.
+///
+/// If the revealed result is `0`, that indicates that `r` had the same value
+/// as the secret input, so the sharing in `Z_p` is returned.
+/// If the revealed result is a `1`, that indicate that `r` was different than
+/// the secret nput, so the sharing 1 - the sharing in `Z_p` is returned.
+impl ConvertShares {
+    #[allow(dead_code)]
+    pub fn new(input: XorShares) -> Self {
+        Self { input }
+    }
+
+    #[allow(dead_code)]
+    pub async fn execute<F: Field, S: Step + SpaceIndex, N: Network<S>>(
+        &self,
+        ctx: &ProtocolContext<'_, S, N>,
+        record_id: RecordId,
+        step0: S,
+        step1: S,
+        step2: S,
+        step3: S,
+    ) -> Result<Vec<Replicated<F>>, BoxError> {
+        let prss = &ctx.participant[step0];
+        let (left, right) = prss.generate_values(record_id.into());
+
+        let futures = (0..self.input.num_bits).into_iter().map(|i| async move {
+            let inner_record_id = RecordId::from(
+                u32::from(record_id) * u32::from(self.input.num_bits) + u32::from(i),
+            );
+            let b0 = left & (1 << i) != 0;
+            let b1 = right & (1 << i) != 0;
+
+            let input = self.input.packed_bits & (1 << i) != 0;
+
+            let input_xor_r = input ^ b0;
+
+            let r_binary = ReplicatedBinary::new(b0, b1);
+
+            let r_big_field: Replicated<F> = GenRandom::new(r_binary)
+                .execute(ctx, inner_record_id, step1, step2)
+                .await?;
+
+            let revealed_output =
+                RevealAdditiveBinary::execute(ctx, step3, inner_record_id, input_xor_r).await?;
+
+            if revealed_output {
+                Ok(Replicated::<F>::one(ctx.identity) - r_big_field)
+            } else {
+                Ok(r_big_field)
+            }
+        });
+        try_join_all(futures).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        field::{Field, Fp31},
+        protocol::{
+            modulus_conversion::convert_shares::{ConvertShares, XorShares},
+            QueryId, RecordId, SpaceIndex, Step,
+        },
+        test_fixture::{make_contexts, make_world, validate_and_reconstruct, TestWorld},
+    };
+    use futures::future::try_join_all;
+    use proptest::prelude::Rng;
+
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+    struct ModulusConversionTestStep {
+        prss_space_number: u8,
+    }
+
+    impl Step for ModulusConversionTestStep {}
+
+    impl SpaceIndex for ModulusConversionTestStep {
+        const MAX: usize = 5;
+
+        fn as_usize(&self) -> usize {
+            usize::from(self.prss_space_number)
+        }
+    }
+
+    #[tokio::test]
+    pub async fn convert_shares() {
+        let mut rng = rand::thread_rng();
+
+        let world: TestWorld<ModulusConversionTestStep> = make_world(QueryId);
+        let context = make_contexts(&world);
+        let ctx0 = &context[0];
+        let ctx1 = &context[1];
+        let ctx2 = &context[2];
+
+        let mask = (1_u64 << 41) - 1; // in binary, a sequence of 40 ones
+        let match_key: u64 = rng.gen::<u64>() & mask;
+        let share_0 = rng.gen::<u64>() & mask;
+        let share_1 = rng.gen::<u64>() & mask;
+        let share_2 = match_key ^ share_0 ^ share_1;
+
+        let record_id = RecordId::from(0_u32);
+
+        let step1 = ModulusConversionTestStep {
+            prss_space_number: 1,
+        };
+        let step2 = ModulusConversionTestStep {
+            prss_space_number: 2,
+        };
+        let step3 = ModulusConversionTestStep {
+            prss_space_number: 3,
+        };
+        let step4 = ModulusConversionTestStep {
+            prss_space_number: 4,
+        };
+
+        let awaited_futures = try_join_all(vec![
+            ConvertShares::new(XorShares {
+                num_bits: 40,
+                packed_bits: share_0,
+            })
+            .execute(ctx0, record_id, step1, step2, step3, step4),
+            ConvertShares::new(XorShares {
+                num_bits: 40,
+                packed_bits: share_1,
+            })
+            .execute(ctx1, record_id, step1, step2, step3, step4),
+            ConvertShares::new(XorShares {
+                num_bits: 40,
+                packed_bits: share_2,
+            })
+            .execute(ctx2, record_id, step1, step2, step3, step4),
+        ])
+        .await
+        .unwrap();
+
+        let v0 = &awaited_futures[0];
+        let v1 = &awaited_futures[1];
+        let v2 = &awaited_futures[2];
+
+        for i in 0..40 {
+            let bit_of_match_key = match_key & (1 << i) != 0;
+
+            let share_of_bit: Fp31 = validate_and_reconstruct((v0[i], v1[i], v2[i]));
+            if bit_of_match_key {
+                assert_eq!(share_of_bit, Fp31::ONE);
+            } else {
+                assert_eq!(share_of_bit, Fp31::ZERO);
+            }
+        }
+    }
+}

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -77,17 +77,6 @@ impl ConvertShares {
         let futures = bits
             .into_iter()
             .map(|(ctx, b0, b1, input_xor_r)| async move {
-                /*
-                            let inner_record_id = RecordId::from(
-                                u32::from(record_id) * u32::from(self.input.num_bits) + u32::from(i),
-                            );
-                            let b0 = left & (1 << i) != 0;
-                            let b1 = right & (1 << i) != 0;
-
-                            let input = self.input.packed_bits & (1 << i) != 0;
-
-                            let input_xor_r = input ^ b0;
-                */
                 let r_binary = ReplicatedBinary::new(b0, b1);
 
                 let gen_random = GenRandom::new(r_binary);

--- a/src/protocol/modulus_conversion/mod.rs
+++ b/src/protocol/modulus_conversion/mod.rs
@@ -1,1 +1,2 @@
+mod convert_shares;
 mod gen_random;

--- a/src/protocol/reveal_additive_binary.rs
+++ b/src/protocol/reveal_additive_binary.rs
@@ -13,13 +13,13 @@ pub struct RevealValue {
     share: bool,
 }
 
-/// This implements reveal algorithm
+/// This implements a reveal algorithm for an additive binary secret sharing.
 /// As this is an additive sharing, each helper has just one boolean share
 /// As such, reveal requires each helper to send their share both left and right
 /// Put another way, each `P_i` sends `\[a\]_i` to `P_i+1` and `P_i-1`
 /// and then reconstructs a from` \[a\]_i`, `\[a\]_i+i` and `\[a\]i−1`.
-// Input: Each helpers know their own secret shares
-// Output: At the end of the protocol, all 3 helpers know a revealed (or opened) secret
+/// Input: Each helpers know their own secret shares
+/// Output: At the end of the protocol, all 3 helpers know a revealed (or opened) secret
 #[derive(Debug)]
 pub struct RevealAdditiveBinary {}
 

--- a/src/protocol/reveal_additive_binary.rs
+++ b/src/protocol/reveal_additive_binary.rs
@@ -1,0 +1,103 @@
+use crate::{
+    error::BoxError,
+    helpers::{fabric::Network, prss::SpaceIndex, Direction},
+    protocol::{context::ProtocolContext, RecordId, Step},
+};
+
+use serde::{Deserialize, Serialize};
+
+/// A message sent by each helper when they've revealed their own shares
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct RevealValue {
+    share: bool,
+}
+
+/// This implements reveal algorithm
+/// As this is an additive sharing, each helper has just one boolean share
+/// As such, reveal requires each helper to send their share both left and right
+/// Put another way, each `P_i` sends `\[a\]_i` to `P_i+1` and `P_i-1`
+/// and then reconstructs a from` \[a\]_i`, `\[a\]_i+i` and `\[a\]i−1`.
+// Input: Each helpers know their own secret shares
+// Output: At the end of the protocol, all 3 helpers know a revealed (or opened) secret
+#[derive(Debug)]
+pub struct RevealAdditiveBinary {}
+
+impl RevealAdditiveBinary {
+    #[allow(dead_code)]
+    pub async fn execute<S: Step + SpaceIndex, N: Network<S>>(
+        ctx: &ProtocolContext<'_, S, N>,
+        step: S,
+        record_id: RecordId,
+        input: bool,
+    ) -> Result<bool, BoxError> {
+        let mut channel = ctx.gateway.get_channel(step);
+
+        channel
+            .send(
+                channel.identity().peer(Direction::Left),
+                record_id,
+                RevealValue { share: input },
+            )
+            .await?;
+
+        channel
+            .send(
+                channel.identity().peer(Direction::Right),
+                record_id,
+                RevealValue { share: input },
+            )
+            .await?;
+
+        // Sleep until `helper's left` sends their share
+        let share_from_left: RevealValue = channel
+            .receive(channel.identity().peer(Direction::Left), record_id)
+            .await?;
+
+        // Sleep until `helper's right` sends their share
+        let share_from_right: RevealValue = channel
+            .receive(channel.identity().peer(Direction::Right), record_id)
+            .await?;
+
+        Ok(input ^ share_from_left.share ^ share_from_right.share)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::Rng;
+    use tokio::try_join;
+
+    use crate::{
+        protocol::{reveal_additive_binary::RevealAdditiveBinary, QueryId, RecordId},
+        test_fixture::{make_contexts, make_world, TestStep, TestWorld},
+    };
+
+    #[tokio::test]
+    pub async fn reveal() {
+        let mut rng = rand::thread_rng();
+
+        for i in 0..10 {
+            let b0 = rng.gen::<bool>();
+            let b1 = rng.gen::<bool>();
+            let b2 = rng.gen::<bool>();
+
+            let input = b0 ^ b1 ^ b2;
+            let record_id = RecordId::from(i);
+
+            let world: TestWorld<TestStep> = make_world(QueryId);
+            let ctx = make_contexts(&world);
+
+            let step = TestStep::Reveal(1);
+
+            let h0_future = RevealAdditiveBinary::execute(&ctx[0], step, record_id, b0);
+            let h1_future = RevealAdditiveBinary::execute(&ctx[1], step, record_id, b1);
+            let h2_future = RevealAdditiveBinary::execute(&ctx[2], step, record_id, b2);
+
+            let f = try_join!(h0_future, h1_future, h2_future).unwrap();
+            assert_eq!(input, f.0);
+            assert_eq!(input, f.1);
+            assert_eq!(input, f.2);
+        }
+    }
+}

--- a/src/secret_sharing/replicated.rs
+++ b/src/secret_sharing/replicated.rs
@@ -13,7 +13,7 @@ pub struct Replicated<T>(T, T);
 
 impl<T: Debug> Debug for Replicated<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({:?}, {:?}", self.0, self.1)
+        write!(f, "({:?}, {:?})", self.0, self.1)
     }
 }
 


### PR DESCRIPTION
Assume that the browser will secret share a match key into XOR secret shares, with each share encrypted towards a different helper.

Upon decryption, each helper will possess just one share (i.e. not a replicated sharing).

Assume we interpret this as a bit-packed array of secret sharings in Z_2. Basically, for each of the bits of the match key, there are three shares, each one boolean, and each helper possesses just one of them.

This ConvertShares protocol takes in a u64 (which is interpreted as a bit-packing of up to 64 of these Z_2 secret sharings) and converts this to a vector of secret-sharings in a larger field, where each element of the vector is a sharing of either zero or one.

Example:

### Match key: 
`0b11001`
### Output:
```
vec![ 
    Replicated<F>, // a random sharing of `1` 
    Replicated<F>, // a random sharing of `1` 
    Replicated<F>, // a random sharing of `0`
    Replicated<F>, // a random sharing of `0`
    Replicated<F>, // a random sharing of `1`
]
```