### PR TITLE
`Mesh` methods take shared reference

### DIFF
--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -88,7 +88,7 @@ impl<N: Network> Mesh<'_, '_, N> {
     /// # Errors
     /// Returns an error if it fails to send the message or if there is a serialization error.
     pub async fn send<T: Message>(
-        &mut self,
+        &self,
         dest: Identity,
         record_id: RecordId,
         msg: T,
@@ -114,7 +114,7 @@ impl<N: Network> Mesh<'_, '_, N> {
     /// # Errors
     /// Returns an error if it fails to receive the message or if a deserialization error occurred
     pub async fn receive<T: Message>(
-        &mut self,
+        &self,
         source: Identity,
         record_id: RecordId,
     ) -> Result<T, Error> {

--- a/src/protocol/reveal.rs
+++ b/src/protocol/reveal.rs
@@ -43,7 +43,7 @@ impl<'a, 'b: 'a, N: Network> Reveal<'a, 'b, N> {
     /// i.e. their own shares and received share.
     #[allow(dead_code)]
     pub async fn execute<F: Field>(self, input: Replicated<F>) -> Result<F, BoxError> {
-        let mut channel = self.context.mesh();
+        let channel = self.context.mesh();
 
         let inputs = input.as_tuple();
         channel

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -52,7 +52,7 @@ impl<'a, N: Network> SecureMul<'a, N> {
         a: Replicated<F>,
         b: Replicated<F>,
     ) -> Result<Replicated<F>, BoxError> {
-        let mut channel = self.gateway.mesh(self.step);
+        let channel = self.gateway.mesh(self.step);
 
         // generate shared randomness.
         let (s0, s1) = self.prss.generate_fields(self.record_id.into());

--- a/src/protocol/sort/reshare.rs
+++ b/src/protocol/sort/reshare.rs
@@ -47,7 +47,7 @@ impl<F: Field> Reshare<F> {
         record_id: RecordId,
         to_helper: Identity,
     ) -> Result<Replicated<F>, BoxError> {
-        let mut channel = ctx.mesh();
+        let channel = ctx.mesh();
         let prss = ctx.prss();
         let (r0, r1) = prss.generate_fields(record_id.into());
 


### PR DESCRIPTION
There is currently no need to take an exclusive reference to self. Given that `Mesh` is no longer a trait, this change is fairly easy to make.

Taking a shared reference instead of `&mut self` enables protocols to run multiple concurrent multiplications at the same time.

The use case for it is presented in #128