### PR TITLE
Make benchmarks compile again

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,12 @@ jobs:
         with:
           command: build
           args: --tests
+# todo: enable this action once Step trait no longer causes release build failures
+#      - uses: actions-rs/cargo@v1
+#        name: Release Build
+#        with:
+#          command: build
+#          args: --release
 
       - uses: actions-rs/cargo@v1
         name: Check formatting

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -32,9 +32,9 @@ use std::{fmt::Debug, hash::Hash};
 pub trait Step: AsRef<str> {}
 
 // In test code, allow a string (or string reference) to be used as a `Step`.
-#[cfg(debug_assertions)]
+#[cfg(any(feature = "test-fixture", debug_assertions))]
 impl Step for String {}
-#[cfg(debug_assertions)]
+#[cfg(any(feature = "test-fixture", debug_assertions))]
 impl Step for str {}
 
 /// The representation of a unique step in protocol execution.


### PR DESCRIPTION
#128 broke the release build

```bash
☻  cargo build --release                                                                                                                                                                                                                                                                                                      9fe8280 ✗
   Compiling raw-ipa v0.1.0 (/Users/koshelev/workspace/raw-ipa)
error[E0277]: the trait bound `std::string::String: protocol::Step` is not satisfied
  --> src/protocol/modulus_conversion/convert_shares.rs:74:25
   |
74 |             (ctx.narrow(&format!("bit:{}", i)), b0, b1, input_xor_r)
   |                  ------ ^^^^^^^^^^^^^^^^^^^^^ the trait `protocol::Step` is not implemented for `std::string::String`
   |                  |
   |                  required by a bound introduced by this call
   |
   = help: the following other types implement trait `protocol::Step`:
             IpaProtocolStep
             ShuffleStep
             SortStep
             StreamingStep
             convert_shares::Step
note: required by a bound in `ProtocolContext::<'a, N>::narrow`
  --> src/protocol/context.rs:47:22
   |
47 |     pub fn narrow<S: Step>(&self, step: &S) -> Self {
   |                      ^^^^ required by this bound in `ProtocolContext::<'a, N>::narrow`
```

Modulus conversion uses strings as step and it is not allowed in release builds.

As temporary mitigation, I've enabled these conversions when test configuration is used. The proper fix would be to use steps that can be represented as strings for debug builds and as something else for release builds.